### PR TITLE
Refactor plugin to use octo.exe instead of the API to create/deploy releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
+.idea
+*.class
+
+# Package Files #
+*.jar
+*.nupkg
+.idea
+*.iml
+
 /target/*
 /work/*

--- a/pom.xml
+++ b/pom.xml
@@ -62,13 +62,20 @@ THE SOFTWARE.
   </developers>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>2.63</jenkins.version>
 	<java.level>7</java.level>
 	<jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-	<hpi-plugin.version>1.121</hpi-plugin.version>
+	<hpi-plugin.version>2.6</hpi-plugin.version>
+    <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-htmlunit</artifactId>
+      <version>2.18-1</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -85,6 +92,17 @@ THE SOFTWARE.
     </pluginRepository>
   </pluginRepositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <reporting>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,10 @@ THE SOFTWARE.
   </developers>
 
   <properties>
-    <jenkins.version>2.63</jenkins.version>
 	<java.level>7</java.level>
+    <jenkins.version>1.625.3</jenkins.version>
 	<jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-	<hpi-plugin.version>2.6</hpi-plugin.version>
+	<hpi-plugin.version>1.121</hpi-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ THE SOFTWARE.
   <name>OctopusDeploy Plugin</name>
   <groupId>hudson.plugins.octopusdeploy</groupId>
   <artifactId>octopusdeploy</artifactId>
-  <version>1.9.0-SNAPSHOT</version>
+  <version>1.9.0</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/OctopusDeploy+Plugin</url>
 
@@ -40,7 +40,7 @@ THE SOFTWARE.
     <connection>scm:git:https://github.com/jenkinsci/octopusdeploy-plugin.git</connection>
     <developerConnection>scm:git:https://git@github.com/jenkinsci/octopusdeploy-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/octopusdeploy-plugin</url>
-    <tag>octopusdeploy-1.5.0</tag>
+    <tag>octopusdeploy-1.9.0</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ THE SOFTWARE.
   <name>OctopusDeploy Plugin</name>
   <groupId>hudson.plugins.octopusdeploy</groupId>
   <artifactId>octopusdeploy</artifactId>
-  <version>1.9.0</version>
+  <version>1.10.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/OctopusDeploy+Plugin</url>
 
@@ -40,7 +40,7 @@ THE SOFTWARE.
     <connection>scm:git:https://github.com/jenkinsci/octopusdeploy-plugin.git</connection>
     <developerConnection>scm:git:https://git@github.com/jenkinsci/octopusdeploy-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/octopusdeploy-plugin</url>
-    <tag>octopusdeploy-1.9.0</tag>
+    <tag>octopusdeploy-1.5.0</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@ THE SOFTWARE.
   </developers>
 
   <properties>
-	<java.level>7</java.level>
     <jenkins.version>1.625.3</jenkins.version>
+	<java.level>8</java.level>
 	<jenkins-test-harness.version>2.13</jenkins-test-harness.version>
 	<hpi-plugin.version>1.121</hpi-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>

--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
@@ -92,6 +92,13 @@ public abstract class AbstractOctopusDeployRecorder extends Recorder {
         return waitForDeployment;
     }
 
+    /**
+     * Whether or not to enable verbose logging
+     */
+    protected boolean verboseLogging;
+    public boolean getVerboseLogging() {
+        return verboseLogging;
+    }
 
     /**
      * Get the default OctopusDeployServer from OctopusDeployPlugin configuration
@@ -190,6 +197,11 @@ public abstract class AbstractOctopusDeployRecorder extends Recorder {
         commands.add(apiKey);
         commands.add(OctoConstants.Commands.Arguments.PROJECT_NAME_ARGUMENT);
         commands.add(project);
+
+        if (verboseLogging) {
+            commands.add("--debug");
+        }
+
 
         return commands;
     }

--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
@@ -185,6 +185,7 @@ public abstract class AbstractOctopusDeployRecorder extends Recorder {
         OctopusDeployServer server = getOctopusDeployServer(this.serverId);
         String serverUrl = server.getUrl();
         String apiKey = server.getApiKey().getPlainText();
+        boolean ignoreSslErrors = server.isIgnoreSslErrors();
 
         checkState(StringUtils.isNotBlank(serverUrl), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Octopus URL"));
         checkState(StringUtils.isNotBlank(apiKey), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "API Key"));
@@ -197,6 +198,10 @@ public abstract class AbstractOctopusDeployRecorder extends Recorder {
         commands.add(apiKey);
         commands.add(OctoConstants.Commands.Arguments.PROJECT_NAME_ARGUMENT);
         commands.add(project);
+
+        if (ignoreSslErrors) {
+            commands.add("--ignoreSslErrors");
+        }
 
         if (verboseLogging) {
             commands.add("--debug");

--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
@@ -177,7 +177,7 @@ public abstract class AbstractOctopusDeployRecorder extends Recorder {
 
         OctopusDeployServer server = getOctopusDeployServer(this.serverId);
         String serverUrl = server.getUrl();
-        String apiKey = server.getApiKey();
+        String apiKey = server.getApiKey().getPlainText();
 
         checkState(StringUtils.isNotBlank(serverUrl), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Octopus URL"));
         checkState(StringUtils.isNotBlank(apiKey), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "API Key"));

--- a/src/main/java/hudson/plugins/octopusdeploy/OctoInstallation.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctoInstallation.java
@@ -1,0 +1,140 @@
+package hudson.plugins.octopusdeploy;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import hudson.model.Descriptor;
+import hudson.model.EnvironmentSpecific;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.slaves.NodeSpecific;
+import hudson.tools.*;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.Collections;
+import java.util.List;
+
+public class OctoInstallation extends ToolInstallation implements NodeSpecific<OctoInstallation>, EnvironmentSpecific<OctoInstallation> {
+
+    public static transient final String DEFAULT = "Default";
+
+    private static final long serialVersionUID = 1;
+
+    @SuppressWarnings("unused")
+    /**
+     * Backward compatibility
+     */
+    private transient String pathToOcto;
+
+    @DataBoundConstructor
+    public OctoInstallation(String name, String home) {
+        super(name, home, null);
+    }
+
+    @Override
+    public OctoInstallation forNode(@NonNull Node node, TaskListener log) throws IOException, InterruptedException {
+        return new OctoInstallation(getName(), translateFor(node, log));
+    }
+    @Override
+    public OctoInstallation forEnvironment(EnvVars environment) {
+        return new OctoInstallation(getName(), environment.expand(getHome()));
+    }
+
+    protected Object readResolve() {
+        if (this.pathToOcto != null) {
+            return new OctoInstallation(this.getName(), this.pathToOcto);
+        }
+        return this;
+    }
+
+    public String getPathToOctoExe() {
+        return getHome();
+    }
+
+    public static OctoInstallation getDefaultInstallation() {
+        DescriptorImpl octoTools = Jenkins.getInstance().getDescriptorByType(OctoInstallation.DescriptorImpl.class);
+        OctoInstallation tool = octoTools.getInstallation(OctoInstallation.DEFAULT);
+        if (tool != null) {
+            return tool;
+        } else {
+            OctoInstallation[] installations = octoTools.getInstallations();
+            if (installations.length > 0) {
+                return installations[0];
+            } else {
+                onLoaded();
+                return octoTools.getInstallations()[0];
+            }
+        }
+    }
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
+    public static void onLoaded() {
+        DescriptorImpl descriptor = (OctoInstallation.DescriptorImpl) Jenkins.getInstance().getDescriptor(OctoInstallation.class);
+        assert descriptor != null;
+        OctoInstallation[] installations = descriptor.getInstallations();
+        if (installations != null && installations.length > 0) {
+            return;
+        }
+        String defaultOctoExe = isWindows() ? "Octo.exe" : "Octo";
+        OctoInstallation tool = new OctoInstallation(DEFAULT, defaultOctoExe);
+        descriptor.setInstallations(tool);
+        descriptor.save();
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(getClass());
+    }
+
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+
+
+    @Extension
+    public static class DescriptorImpl extends ToolDescriptor<OctoInstallation> {
+
+        public DescriptorImpl() {
+            super();
+            load();
+        }
+
+        public String getDisplayName() {
+            return "Octopus CLI";
+        }
+
+        @Nullable
+        public OctoInstallation getInstallation(String name) {
+            for (OctoInstallation i : getInstallations()) {
+                if (i.getName().equals(name)) {
+                    return i;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) {
+            JSONObject json = formData.getJSONObject("octopusCli");
+
+            if(!json.isEmpty()) {
+                OctoInstallation[] tools = req.bindJSONToList(OctoInstallation.class, json.get("tools"))
+                        .toArray((OctoInstallation[]) Array.newInstance(OctoInstallation.class, 0));
+                setInstallations(tools);
+            }
+            save();
+
+            return true;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
@@ -41,7 +41,7 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
     }
 
     @DataBoundConstructor
-    public OctopusDeployDeploymentRecorder(String serverId, String toolId, String project, String releaseVersion, String environment, String tenant, String variables, boolean waitForDeployment) {
+    public OctopusDeployDeploymentRecorder(String serverId, String toolId, String project, String releaseVersion, String environment, String tenant, String variables, boolean waitForDeployment, boolean verboseLogging) {
         this.serverId = serverId.trim();
         this.toolId = toolId.trim();
         this.project = project.trim();
@@ -50,6 +50,7 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
         this.tenant = tenant == null ? null : tenant.trim(); // Otherwise this can throw on plugin version upgrade
         this.variables = variables.trim();
         this.waitForDeployment = waitForDeployment;
+        this.verboseLogging = verboseLogging;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
@@ -1,5 +1,6 @@
 package hudson.plugins.octopusdeploy;
 
+import com.google.common.base.Splitter;
 import com.octopusdeploy.api.data.Task;
 import com.octopusdeploy.api.data.Release;
 import com.octopusdeploy.api.*;
@@ -7,12 +8,16 @@ import java.io.*;
 import java.util.*;
 import hudson.*;
 import hudson.model.*;
+import hudson.plugins.octopusdeploy.constants.OctoConstants;
 import hudson.tasks.*;
 import hudson.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.json.*;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.*;
+
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Executes deployments of releases.
@@ -36,8 +41,9 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
     }
 
     @DataBoundConstructor
-    public OctopusDeployDeploymentRecorder(String serverId, String project, String releaseVersion, String environment, String tenant, String variables, boolean waitForDeployment) {
+    public OctopusDeployDeploymentRecorder(String serverId, String toolId, String project, String releaseVersion, String environment, String tenant, String variables, boolean waitForDeployment) {
         this.serverId = serverId.trim();
+        this.toolId = toolId.trim();
         this.project = project.trim();
         this.releaseVersion = releaseVersion.trim();
         this.environment = environment.trim();
@@ -56,8 +62,6 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
             return success;
         }
 
-        logStartHeader(log);
-
         VariableResolver resolver = build.getBuildVariableResolver();
         EnvVars envVars;
         try {
@@ -74,128 +78,67 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
         String tenant = envInjector.injectEnvironmentVariableValues(this.tenant);
         String variables = envInjector.injectEnvironmentVariableValues(this.variables);
 
-        com.octopusdeploy.api.data.Project p = null;
-        try {
-            p = getApi().getProjectsApi().getProjectByName(project);
-        } catch (Exception ex) {
-            log.fatal(String.format("Retrieving project name '%s' failed with message '%s'",
-                    project, ex.getMessage()));
-            success = false;
-        }
-        com.octopusdeploy.api.data.Environment env = null;
-        try {
-            env = getApi().getEnvironmentsApi().getEnvironmentByName(environment);
-        } catch (Exception ex) {
-            log.fatal(String.format("Retrieving environment name '%s' failed with message '%s'",
-                    environment, ex.getMessage()));
-            success = false;
-        }
+        logStartHeader(log);
 
-        if (p == null) {
-            log.fatal("Project was not found.");
-            success = false;
-        }
-        if (env == null) {
-            log.fatal("Environment was not found.");
-            success = false;
-        }
-        if (!success) // Early exit
-        {
-            return success;
-        }
+        checkState(StringUtils.isNotBlank(project), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Project name"));
+        checkState(StringUtils.isNotBlank(environment), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Environment name"));
+        checkState(StringUtils.isNotBlank(releaseVersion), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Version"));
 
-        String tenantId = null;
-        if (tenant != null && !tenant.isEmpty()) {
-            com.octopusdeploy.api.data.Tenant ten = null;
-            try {
-                ten = getApi().getTenantsApi().getTenantByName(tenant);
-                if (ten != null) {
-                    tenantId = ten.getId();
-                } else {
-                    log.fatal(String.format("Retrieving tenant name '%s' failed with message 'not found'", tenant));
-                    return false;
-                }
-            } catch (Exception ex) {
-                log.fatal(String.format("Retrieving tenant name '%s' failed with message '%s'",
-                        tenant, ex.getMessage()));
-                return false;
-            }
-        }
-
-        Set<com.octopusdeploy.api.data.Release> releases = null;
-        try {
-            releases = getApi().getReleasesApi().getReleasesForProject(p.getId());
-        } catch (Exception ex) {
-            log.fatal(String.format("Retrieving releases for project '%s' failed with message '%s'",
-                    project, ex.getMessage()));
-            success = false;
-        }
-        if (releases == null) {
-            log.fatal("Releases was not found.");
-            return false;
-        }
-        Release releaseToDeploy = null;
-        for(Release r : releases) {
-            if (releaseVersion.equals(r.getVersion()))
-            {
-                releaseToDeploy = r;
-                break;
-            }
-        }
-        if (releaseToDeploy == null) // early exit
-        {
-            log.fatal(String.format("Unable to find release version %s for project %s", releaseVersion, project));
-            return false;
-        }
         Properties properties = new Properties();
         try {
             properties.load(new StringReader(variables));
         } catch (Exception ex) {
-            log.fatal(String.format("Unable to load entry variables failed with message '%s'",
-                    ex.getMessage()));
-            success = false;
+            log.fatal(String.format("Unable to load entry variables: '%s'", ex.getMessage()));
+            return false;
         }
 
-        // TODO: Can we tell if we need to call? For now I will always try and get variable and use if I find them
-        Set<com.octopusdeploy.api.data.Variable> variablesForDeploy = null;
+        final List<String> commands = buildCommonCommandArguments(OctoConstants.Commands.DEPLOY_RELEASE_COMMAND);
 
-        try {
-            String releaseId = releaseToDeploy.getId();
-            String environmentId = env.getId();
-            variablesForDeploy = getApi().getVariablesApi().getVariablesByReleaseAndEnvironment(releaseId, environmentId, properties);
-        } catch (Exception ex) {
-            log.fatal(String.format("Retrieving variables for release '%s' to environment '%s' failed with message '%s'",
-                    releaseToDeploy.getId(), env.getName(), ex.getMessage()));
-            success = false;
+        final Iterable<String> environmentNameSplit = Splitter.on(',')
+                .trimResults()
+                .omitEmptyStrings()
+                .split(environment);
+        for(String env : environmentNameSplit) {
+            commands.add("--deployTo");
+            commands.add(env);
         }
-        try {
-            String results = getApi().getDeploymentsApi().executeDeployment(releaseToDeploy.getId(), env.getId(), tenantId, variablesForDeploy);
-            if (isTaskJson(results)) {
-                JSON resultJson = JSONSerializer.toJSON(results);
-                String urlSuffix = ((JSONObject)resultJson).getJSONObject("Links").getString("Web");
-                String url = getOctopusDeployServer().getUrl();
-                if (url.endsWith("/")) {
-                    url = url.substring(0, url.length() - 1);
-                }
-                log.info("Deployment executed: \n\t" + url + urlSuffix);
-                build.addAction(new BuildInfoSummary(BuildInfoSummary.OctopusDeployEventType.Deployment, url + urlSuffix));
-                if (waitForDeployment) {
-                    log.info("Waiting for deployment to complete.");
-                    String resultState = waitForDeploymentCompletion(resultJson, getApi(), log);
-                    if (resultState == null) {
-                        log.info("Marking build failed due to failure in waiting for deployment to complete.");
-                        success = false;
-                    }
 
-                    if ("Failed".equals(resultState)) {
-                        log.info("Marking build failed due to deployment task status.");
-                        success = false;
-                    }
-                }
+        commands.add("--version");
+        commands.add(releaseVersion);
+
+        if(StringUtils.isNotBlank(tenant)) {
+            Iterable<String> tenantsSplit = Splitter.on(',')
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .split(tenant);
+            for(String t : tenantsSplit) {
+                commands.add("--tenant");
+                commands.add(t);
             }
-        } catch (IOException ex) {
-            log.fatal("Failed to deploy: " + ex.getMessage());
-            success = false;
+        }
+
+        if(waitForDeployment) {
+            commands.add("--progress");
+        }
+
+        for(String variableName : properties.stringPropertyNames()) {
+            String variableValue = properties.getProperty(variableName);
+            commands.add("--variable");
+            commands.add(String.format("%s:%s", variableName, variableValue));
+        }
+
+        if(success) {
+            try {
+                final Boolean[] masks = getMasks(commands, OctoConstants.Commands.Arguments.MaskedArguments);
+                Result result = launchOcto(launcher, commands, masks, envVars, listener);
+                success = result.equals(Result.SUCCESS);
+                if(success) {
+                    //build.addAction(new BuildInfoSummary(BuildInfoSummary.OctopusDeployEventType.Deployment, url + urlSuffix));
+                }
+            } catch (Exception ex) {
+                log.fatal("Failed to deploy: " + ex.getMessage());
+                success = false;
+            }
         }
 
         return success;
@@ -296,7 +239,7 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
      * The class is marked as public so that it can be accessed from views.
      */
     @Extension
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+    public static final class DescriptorImpl extends AbstractOctopusDeployDescriptorImpl {
         private static final String PROJECT_RELEASE_VALIDATION_MESSAGE = "Project must be set to validate release.";
         private static final String SERVER_ID_VALIDATION_MESSAGE = "Could not validate without a valid Server ID.";
 
@@ -312,36 +255,6 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
         @Override
         public String getDisplayName() {
             return "OctopusDeploy Deployment";
-        }
-
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
-            save();
-            return true;
-        }
-
-        private OctopusApi getApiByServerId(String serverId){
-            return AbstractOctopusDeployRecorder.getOctopusDeployServer(serverId).getApi();
-        }
-
-        public String getDefaultOctopusDeployServerId() {
-
-            OctopusDeployServer server = AbstractOctopusDeployRecorder.getDefaultOctopusDeployServer();
-            if(server != null){
-                return server.getId();
-            }
-            return null;
-        }
-
-        /**
-         * Check that the serverId field is not empty.
-         * @param serverId The id of OctopusDeployServer in the configuration.
-         * @return Ok if not empty, error otherwise.
-         */
-        public FormValidation doCheckServerId(@QueryParameter String serverId) {
-
-            serverId = serverId.trim();
-            return OctopusValidator.validateServerId(serverId);
         }
 
         /**
@@ -411,15 +324,6 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
             OctopusApi api = getApiByServerId(serverId);
             OctopusValidator validator = new OctopusValidator(api);
             return validator.validateEnvironment(environment);
-        }
-
-        /**
-         * Data binding that returns all configured Octopus server ids to be used in the serverId drop-down list.
-         * @return ComboBoxModel
-         */
-        public ComboBoxModel doFillServerIdItems() {
-
-            return new ComboBoxModel(getOctopusDeployServersIds());
         }
 
         /**

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPlugin.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPlugin.java
@@ -109,7 +109,7 @@ public class OctopusDeployPlugin extends GlobalPluginConfiguration {
                 return FormValidation.warning("Please set a ServerID");
             }
             for (OctopusDeployServer s:getOctopusDeployServers()){
-                if (serverId.equals(s.getId()) && !url.equals(s.getUrl()) && !apiKey.equals(s.getApiKey())){
+                if (serverId.equals(s.getId()) && !url.equals(s.getUrl()) && !apiKey.equals(s.getApiKey().getEncryptedValue())){
                     return FormValidation.error("The Server ID you entered already exists.");
                 }
             }
@@ -169,7 +169,7 @@ public class OctopusDeployPlugin extends GlobalPluginConfiguration {
             if (apiKey.isEmpty()) {
                 return FormValidation.warning("Please set a API Key generated from OctopusDeploy Server.");
             }
-            if (!apiKey.matches("API\\-\\w{25,27}")) {
+            if (!Secret.decrypt(apiKey).getPlainText().matches("API\\-\\w{25,27}")) {
                 return FormValidation.error("Supplied Octopus API Key format is invalid. It should look like API-XXXXXXXXXXXXXXXXXXXXXXXXXXX");
             }
             return FormValidation.ok();

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPlugin.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPlugin.java
@@ -78,7 +78,7 @@ public class OctopusDeployPlugin extends GlobalPluginConfiguration {
 		@SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD", justification = "This is for backwards compatiblity on Jenkins plugin upgrade" )
         private void loadLegacyOctopusDeployServerConfig() {
             if (doesLegacyOctopusDeployServerExist()){
-                OctopusDeployServer server = new OctopusDeployServer("default", octopusHost, Secret.fromString(apiKey), true);
+                OctopusDeployServer server = new OctopusDeployServer("default", octopusHost, Secret.fromString(apiKey), true, false);
                 if(octopusDeployServers == null)
                 {
                     octopusDeployServers = new ArrayList<>();

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPlugin.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPlugin.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalPluginConfiguration;
@@ -77,7 +78,7 @@ public class OctopusDeployPlugin extends GlobalPluginConfiguration {
 		@SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD", justification = "This is for backwards compatiblity on Jenkins plugin upgrade" )
         private void loadLegacyOctopusDeployServerConfig() {
             if (doesLegacyOctopusDeployServerExist()){
-                OctopusDeployServer server = new OctopusDeployServer("default", octopusHost, apiKey, true);
+                OctopusDeployServer server = new OctopusDeployServer("default", octopusHost, Secret.fromString(apiKey), true);
                 if(octopusDeployServers == null)
                 {
                     octopusDeployServers = new ArrayList<>();

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -1,5 +1,6 @@
 package hudson.plugins.octopusdeploy;
 
+import com.google.common.base.Splitter;
 import com.octopusdeploy.api.data.SelectedPackage;
 import com.octopusdeploy.api.data.DeploymentProcessTemplate;
 import com.octopusdeploy.api.*;
@@ -11,6 +12,7 @@ import java.util.*;
 import hudson.*;
 import hudson.FilePath.FileCallable;
 import hudson.model.*;
+import hudson.plugins.octopusdeploy.constants.OctoConstants;
 import hudson.remoting.VirtualChannel;
 import hudson.scm.*;
 import hudson.tasks.*;
@@ -22,6 +24,8 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.export.*;
+
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Creates a release and optionally deploys it.
@@ -112,13 +116,14 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
     public OctopusDeployReleaseRecorder(
-            String serverId, String project, String releaseVersion,
+            String serverId, String toolId, String project, String releaseVersion,
             boolean releaseNotes, String releaseNotesSource, String releaseNotesFile,
             boolean deployThisRelease, String environment, String tenant, String channel, boolean waitForDeployment,
             List<PackageConfiguration> packageConfigs, boolean jenkinsUrlLinkback,
             String defaultPackageVersion) {
 
         this.serverId = serverId.trim();
+        this.toolId = toolId.trim();
         this.project = project.trim();
         this.releaseVersion = releaseVersion.trim();
         this.releaseNotes = releaseNotes;
@@ -147,7 +152,6 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
             log.info("Not creating a release due to job being in FAILED state.");
             return success;
         }
-        logStartHeader(log);
 
         VariableResolver resolver = build.getBuildVariableResolver();
         EnvVars envVars;
@@ -169,33 +173,48 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
         String channel = envInjector.injectEnvironmentVariableValues(this.channel);
         String defaultPackageVersion = envInjector.injectEnvironmentVariableValues(this.defaultPackageVersion);
 
-        com.octopusdeploy.api.data.Project p = null;
-        try {
-            p = getApi().getProjectsApi().getProjectByName(project);
-        } catch (Exception ex) {
-            log.fatal(String.format("Retrieving project name '%s' failed with message '%s'",
-                project, ex.getMessage()));
-            success = false;
+        logStartHeader(log);
+
+        checkState(StringUtils.isNotBlank(project), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Project name"));
+
+        final List<String> commands = buildCommonCommandArguments(OctoConstants.Commands.CREATE_RELEASE_COMMAND);
+
+        if (StringUtils.isNotBlank(releaseVersion)) {
+            commands.add("--version");
+            commands.add(releaseVersion);
         }
-        if (p == null) {
-            log.fatal("Project was not found.");
-            success = false;
+
+        if (StringUtils.isNotBlank(channel)) {
+            commands.add("--channel");
+            commands.add(channel);
         }
-        
-        com.octopusdeploy.api.data.Channel c = null;
-        if (channel != null && !channel.isEmpty()) {
-            try {
-                c = getApi().getChannelsApi().getChannelByName(p.getId(), channel);
-            } catch (Exception ex) {
-                log.fatal(String.format("Retrieving channel name '%s' from project '%s' failed with message '%s'",
-                    channel, project, ex.getMessage()));
-                success = false;
+
+        if (deployThisRelease && StringUtils.isNotBlank(environment)) {
+            final Iterable<String> environmentNameSplit = Splitter.on(',')
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .split(environment);
+            for(final String env : environmentNameSplit) {
+                commands.add("--deployTo");
+                commands.add(env);
             }
-            if (c == null) {
-                log.fatal("Channel was not found.");
-                success = false;
+        }
+
+        if (waitForDeployment) {
+            commands.add("--progress");
+        }
+
+        if (StringUtils.isNotBlank(tenant)) {
+            final Iterable<String> tenantSplit = Splitter.on(',')
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .split(tenant);
+            for(final String t : tenantSplit) {
+                commands.add("--tenant");
+                commands.add(t);
             }
         }
+
         // Check packageVersion
         String releaseNotesContent = "";
 
@@ -231,32 +250,37 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
             return success;
         }
 
-        Set<SelectedPackage> selectedPackages = getCombinedPackageList(p.getId(), packageConfigs, envInjector.injectEnvironmentVariableValues(defaultPackageVersion), log, envInjector);
+        if (StringUtils.isNotBlank(releaseNotesContent)) {
+            commands.add("--releaseNotes");
+            commands.add(JSONSanitizer.getInstance().sanitize(releaseNotesContent));
+        }
+
+        if (StringUtils.isNotBlank(defaultPackageVersion)) {
+            commands.add("--defaultPackageVersion");
+            commands.add(defaultPackageVersion);
+        }
+
+        if (packageConfigs != null && !packageConfigs.isEmpty()) {
+            for (final PackageConfiguration pkg : packageConfigs) {
+                commands.add("--package");
+                if (StringUtils.isNotBlank(pkg.getPackageReferenceName())) {
+                    commands.add(String.format("%s:%s:%s", pkg.getPackageName(), pkg.getPackageReferenceName(), pkg.getPackageVersion()));
+                } else {
+                    commands.add(String.format("%s:%s", pkg.getPackageName(), pkg.getPackageVersion()));
+                }
+            }
+        }
 
         try {
-            // Sanitize the release notes in preparation for JSON
-            releaseNotesContent = JSONSanitizer.getInstance().sanitize(releaseNotesContent);
-            String channelId = null;
-            if (c != null) {
-                channelId = c.getId();
+            final Boolean[] masks = getMasks(commands, OctoConstants.Commands.Arguments.MaskedArguments);
+            Result result = launchOcto(launcher, commands, masks, envVars, listener);
+            success = result.equals(Result.SUCCESS);
+            if (success) {
+                //build.addAction(new BuildInfoSummary(BuildInfoSummary.OctopusDeployEventType.Release, serverUrl + urlSuffix));
             }
-            String results = getApi().getReleasesApi().createRelease(p.getId(), releaseVersion, channelId, releaseNotesContent, selectedPackages);
-            JSONObject json = (JSONObject)JSONSerializer.toJSON(results);
-            String urlSuffix = json.getJSONObject("Links").getString("Web");
-            String url = getOctopusDeployServer().getUrl();
-            if (url.endsWith("/")) {
-                url = url.substring(0, url.length() - 1);
-            }
-            log.info("Release created: \n\t" + url + urlSuffix);
-            build.addAction(new BuildInfoSummary(BuildInfoSummary.OctopusDeployEventType.Release, url + urlSuffix));
         } catch (Exception ex) {
             log.fatal("Failed to create release: " + ex.getMessage());
             success = false;
-        }
-
-        if (success && deployThisRelease) {
-          OctopusDeployDeploymentRecorder deployment = new OctopusDeployDeploymentRecorder(getServerId(), project, releaseVersion, environment, tenant, "", waitForDeployment);
-          success = deployment.perform(build, launcher, listener);
         }
 
         return success;
@@ -449,7 +473,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
      * The class is marked as public so that it can be accessed from views.
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+    public static final class DescriptorImpl extends AbstractOctopusDeployDescriptorImpl {
         private static final String PROJECT_RELEASE_VALIDATION_MESSAGE = "Project must be set to validate release.";
         private static final String SERVER_ID_VALIDATION_MESSAGE = "Could not validate without a valid Server ID.";
 
@@ -460,34 +484,6 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
         @Override
         public String getDisplayName() {
             return "OctopusDeploy Release";
-        }
-
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
-            save();
-            return true;
-        }
-
-        private OctopusApi getApiByServerId(String serverId){
-            return AbstractOctopusDeployRecorder.getOctopusDeployServer(serverId).getApi();
-        }
-
-        public String getDefaultOctopusDeployServerId() {
-            OctopusDeployServer server = AbstractOctopusDeployRecorder.getDefaultOctopusDeployServer();
-            if(server != null){
-                return server.getId();
-            }
-            return null;
-        }
-
-        /**
-         * Check that the serverId field is not empty and does exist.
-         * @param serverId The id of OctopusDeployServer in the configuration.
-         * @return Ok if not empty, error otherwise.
-         */
-        public FormValidation doCheckServerId(@QueryParameter String serverId) {
-            serverId = serverId.trim();
-            return OctopusValidator.validateServerId(serverId);
         }
 
         /**
@@ -591,14 +587,6 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
             OctopusApi api = getApiByServerId(serverId);
             OctopusValidator validator = new OctopusValidator(api);
             return validator.validateEnvironment(environment);
-        }
-
-        /**
-         * Data binding that returns all configured Octopus server ids to be used in the serverId drop-down list.
-         * @return ComboBoxModel
-         */
-        public ComboBoxModel doFillServerIdItems() {
-            return new ComboBoxModel(getOctopusDeployServersIds());
         }
 
         /**

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -120,7 +120,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
             boolean releaseNotes, String releaseNotesSource, String releaseNotesFile,
             boolean deployThisRelease, String environment, String tenant, String channel, boolean waitForDeployment,
             List<PackageConfiguration> packageConfigs, boolean jenkinsUrlLinkback,
-            String defaultPackageVersion) {
+            String defaultPackageVersion, boolean verboseLogging) {
 
         this.serverId = serverId.trim();
         this.toolId = toolId.trim();
@@ -137,6 +137,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
         this.waitForDeployment = waitForDeployment;
         this.releaseNotesJenkinsLinkback = jenkinsUrlLinkback;
         this.defaultPackageVersion = defaultPackageVersion;
+        this.verboseLogging = verboseLogging;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployServer.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployServer.java
@@ -33,6 +33,11 @@ public class OctopusDeployServer implements Serializable {
         return apiKey;
     }
 
+    private boolean ignoreSslErrors;
+    public boolean isIgnoreSslErrors() {
+        return ignoreSslErrors;
+    }
+
     private transient OctopusApi api;
     public OctopusApi getApi() {
         ///TODO use better approach to achieve Laziness
@@ -42,15 +47,16 @@ public class OctopusDeployServer implements Serializable {
         return api;
     }
 
-    public OctopusDeployServer(String serverId, String url, Secret apiKey, boolean isDefault) {
+    public OctopusDeployServer(String serverId, String url, Secret apiKey, boolean isDefault, boolean ignoreSslErrors) {
         this.id = serverId.trim();
         this.url = url.trim();
         this.apiKey = apiKey;
         this.isDefault = isDefault;
+        this.ignoreSslErrors = ignoreSslErrors;
     }
 
     @DataBoundConstructor
-    public OctopusDeployServer(String serverId, String url, String apiKey) {
-        this(serverId, url, Secret.fromString(apiKey), false);
+    public OctopusDeployServer(String serverId, String url, String apiKey, boolean ignoreSslErrors) {
+        this(serverId, url, Secret.fromString(apiKey), false, ignoreSslErrors);
     }
 }

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployServer.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployServer.java
@@ -1,6 +1,7 @@
 package hudson.plugins.octopusdeploy;
 
 import com.octopusdeploy.api.OctopusApi;
+import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
@@ -27,8 +28,8 @@ public class OctopusDeployServer implements Serializable {
         return url;
     }
 
-    private String apiKey;
-    public String getApiKey() {
+    private Secret apiKey;
+    public Secret getApiKey() {
         return apiKey;
     }
 
@@ -36,20 +37,20 @@ public class OctopusDeployServer implements Serializable {
     public OctopusApi getApi() {
         ///TODO use better approach to achieve Laziness
         if (api == null) {
-            api = new OctopusApi(url, apiKey);
+            api = new OctopusApi(url, apiKey.getPlainText());
         }
         return api;
     }
 
-    public OctopusDeployServer(String serverId, String url, String apiKey, boolean isDefault) {
+    public OctopusDeployServer(String serverId, String url, Secret apiKey, boolean isDefault) {
         this.id = serverId.trim();
         this.url = url.trim();
-        this.apiKey = apiKey.trim();
+        this.apiKey = apiKey;
         this.isDefault = isDefault;
     }
 
     @DataBoundConstructor
     public OctopusDeployServer(String serverId, String url, String apiKey) {
-        this(serverId, url, apiKey, false);
+        this(serverId, url, Secret.fromString(apiKey), false);
     }
 }

--- a/src/main/java/hudson/plugins/octopusdeploy/constants/OctoConstants.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/constants/OctoConstants.java
@@ -1,0 +1,22 @@
+package hudson.plugins.octopusdeploy.constants;
+
+public class OctoConstants {
+    public static final class Commands {
+        public static final String CREATE_RELEASE_COMMAND = "create-release";
+        public static final String DEPLOY_RELEASE_COMMAND = "deploy-release";
+
+        public static final class Arguments {
+            public static final String SERVER_URL_ARGUMENT = "--server";
+            public static final String API_KEY_ARGUMENT = "--apiKey";
+
+            public static final String PROJECT_NAME_ARGUMENT = "--project";
+
+            public static final String[] MaskedArguments = {API_KEY_ARGUMENT};
+        }
+    }
+
+    public class Errors {
+
+        public static final String INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT = "OCTOPUS-JENKINS-INPUT-ERROR-0002: %s can not be blank";
+    }
+}

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctoInstallation/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctoInstallation/config.jelly
@@ -1,0 +1,3 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+</j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctoInstallation/global.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctoInstallation/global.jelly
@@ -1,9 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Octopus CLI" name="octopusCli">
-      <f:entry title="Octopus Tools" description="List of Octopus CLI installations that projects can use for deployment.">
+      <f:entry title="Octopus CLI Installations" description="List of Octopus CLI installations that projects can use for deployment.">
               <f:repeatable name="tools" var="tool" items="${descriptor.getInstallations()}" minimum="1"
-                                     header="OctopusDeploy" add="${%Add Octopus Tool}">
+                                     header="Octopus CLI" add="${%Add Octopus Tool}">
               <table width="100%">
             <f:entry title="Name" field="name">
                 <f:textbox value="${tool.name}"/>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctoInstallation/global.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctoInstallation/global.jelly
@@ -1,0 +1,23 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="Octopus CLI" name="octopusCli">
+      <f:entry title="Octopus Tools" description="List of Octopus CLI installations that projects can use for deployment.">
+              <f:repeatable name="tools" var="tool" items="${descriptor.getInstallations()}" minimum="1"
+                                     header="OctopusDeploy" add="${%Add Octopus Tool}">
+              <table width="100%">
+            <f:entry title="Name" field="name">
+                <f:textbox value="${tool.name}"/>
+            </f:entry>
+            <f:entry title="Path" field="home">
+                <f:textbox value="${tool.home}"/>
+            </f:entry>
+            <f:entry title="">
+              <div align="right">
+                  <f:repeatableDeleteButton/>
+              </div>
+            </f:entry>
+           </table>
+          </f:repeatable>
+      </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
@@ -25,6 +25,11 @@
         <j:set var="value" value="${attrs.value ?: instance.serverId ?: default}"/>
         <f:combobox value="${value}"/>
       </f:entry>
+      <f:entry title="Octopus Tool" field="toolId">
+        <j:set var="default" value="${descriptor.getDefaultOctopusToolId()}"/>
+        <j:set var="value" value="${attrs.value ?: instance.toolId ?: default}"/>
+        <f:combobox value="${value}"/>
+      </f:entry>
     </f:advanced>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
@@ -18,6 +18,9 @@
   <f:entry title="Wait for deployment to complete" field="waitForDeployment">
     <f:checkbox  value="false" />
   </f:entry>
+  <f:entry title="Verbose logging" field="verboseLogging">
+    <f:checkbox value="false" />
+  </f:entry>
   <f:section title="Advanced Options">
     <f:advanced>
        <f:entry title="Octopus Server" field="serverId">

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/help-toolId.html
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/help-toolId.html
@@ -1,0 +1,5 @@
+<div>
+    The Octopus Deploy Command Line executable which you want to use for creating this release.
+    <br />
+    Octopus Deploy Command Line executable is set in the Octopus CLI configuration on the Global Tool Configuration page.
+</div>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPlugin/global.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPlugin/global.jelly
@@ -12,7 +12,7 @@
                 <f:textbox value="${server.url}" checkMethod="post"/>
             </f:entry>
             <f:entry title="API Key" field="apiKey">
-                <f:textbox value="${server.apiKey}" />
+                <f:password value="${server.apiKey}" />
                   </f:entry>
                   <f:entry title="">
                       <div align="right">

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPlugin/global.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPlugin/global.jelly
@@ -11,9 +11,12 @@
             <f:entry title="URL" field="url">
                 <f:textbox value="${server.url}" checkMethod="post"/>
             </f:entry>
+            <f:entry title="Ignore SSL Errors" field="ignoreSslErrors">
+                <f:checkbox checked="${server.ignoreSslErrors}" />
+            </f:entry>
             <f:entry title="API Key" field="apiKey">
                 <f:password value="${server.apiKey}" />
-                  </f:entry>
+            </f:entry>
                   <f:entry title="">
                       <div align="right">
                           <f:repeatableDeleteButton/>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/config.jelly
@@ -55,6 +55,12 @@
     </f:entry>
   </f:block>
 
+  <f:block>
+    <f:entry title="Verbose logging" field="verboseLogging">
+        <f:checkbox value="false" />
+    </f:entry>
+  </f:block>
+
   <f:section title="Advanced Options">
     <f:advanced>
        <f:entry title="Octopus Server" field="serverId">

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/config.jelly
@@ -62,6 +62,11 @@
         <j:set var="value" value="${attrs.value ?: instance.serverId ?: default}"/>
         <f:combobox value="${value}"/>
       </f:entry>
+       <f:entry title="Octopus Tool" field="toolId">
+        <j:set var="default" value="${descriptor.getDefaultOctopusToolId()}"/>
+        <j:set var="value" value="${attrs.value ?: instance.toolId ?: default}"/>
+        <f:combobox value="${value}"/>
+      </f:entry>
     </f:advanced>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/help-toolId.html
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/help-toolId.html
@@ -1,0 +1,5 @@
+<div>
+    The Octopus Deploy Command Line executable which you want to use for creating this release.
+    <br />
+    Octopus Deploy Command Line executable is set in the Octopus CLI configuration on the Global Tool Configuration page.
+</div>


### PR DESCRIPTION
Also includes some minor changes to server and step configurations: 
- Store API Key as a `secret` instead of plain-text https://github.com/OctopusDeploy/octopus-jenkins-plugin/commit/c087af46b69f32ce8ceeb0bd7a0216f1cb5af577
- Add verbose logging to steps https://github.com/OctopusDeploy/octopus-jenkins-plugin/commit/a16592727b34a65510149e466342b961b4d1da4a
- Add ignore ssl errors to Octopus connection https://github.com/OctopusDeploy/octopus-jenkins-plugin/commit/2631678e9e1f93c013fb93c1e2b5aff16479bde8