### PR TITLE
Advanced options are a Jelly concept

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorder.java
@@ -22,6 +22,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.types.Commandline;
+import org.apache.xpath.operations.Bool;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -232,6 +233,9 @@ public abstract class AbstractOctopusDeployRecorder extends Recorder {
         return null;
     }
 
+    public Boolean hasAdvancedOptions() {
+        return getVerboseLogging() || (getAdditionalArgs() != null && !getAdditionalArgs().isEmpty());
+    }
 
     /**
      * Get OctopusApi instance for this deployment

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
@@ -56,13 +56,27 @@
   </f:section>
 
   <f:section title="Advanced Options">
-    <f:advanced>
-      <f:entry title="Verbose logging" field="verboseLogging">
-        <f:checkbox value="false" />
-      </f:entry>
-      <f:entry title="Additional command line arguments" field="additionalArgs">
-        <f:textbox />
-      </f:entry>
-    </f:advanced>
+        <j:choose>
+      <j:when test="${instance.hasAdvancedOptions()}">
+            <f:entry title="Verbose logging" field="verboseLogging">
+              <f:checkbox value="false" />
+            </f:entry>
+            <f:entry title="Additional command line arguments" field="additionalArgs">
+              <f:textbox />
+            </f:entry>
+          </j:when>
+          <!--NOTE: the double up of the controls in the advanced section, one for when they have a value,
+            to show expanded, the other case when no value set yet -->
+          <j:otherwise>
+            <f:advanced>
+              <f:entry title="Verbose logging" field="verboseLogging">
+                <f:checkbox value="false" />
+              </f:entry>
+              <f:entry title="Additional command line arguments" field="additionalArgs">
+                <f:textbox />
+              </f:entry>
+            </f:advanced>
+          </j:otherwise>
+        </j:choose>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPackRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPackRecorder/config.jelly
@@ -34,13 +34,27 @@
     </f:entry>
   </f:section>
   <f:section title="Advanced Options">
-    <f:advanced>
-      <f:entry title="Verbose logging" field="verboseLogging">
-        <f:checkbox value="false" />
-      </f:entry>
-      <f:entry title="Additional command line arguments" field="additionalArgs">
-        <f:textbox />
-      </f:entry>
-    </f:advanced>
+    <j:choose>
+      <j:when test="${instance.hasAdvancedOptions()}">
+        <f:entry title="Verbose logging" field="verboseLogging">
+          <f:checkbox value="false" />
+        </f:entry>
+        <f:entry title="Additional command line arguments" field="additionalArgs">
+          <f:textbox />
+        </f:entry>
+      </j:when>
+      <!--NOTE: the double up of the controls in the advanced section, one for when they have a value,
+        to show expanded, the other case when no value set yet -->
+      <j:otherwise>
+        <f:advanced>
+          <f:entry title="Verbose logging" field="verboseLogging">
+            <f:checkbox value="false" />
+          </f:entry>
+          <f:entry title="Additional command line arguments" field="additionalArgs">
+            <f:textbox />
+          </f:entry>
+        </f:advanced>
+      </j:otherwise>
+    </j:choose>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorder/config.jelly
@@ -46,13 +46,27 @@
     </f:entry>
   </f:section>
   <f:section title="Advanced Options">
-    <f:advanced>
-      <f:entry title="Verbose logging" field="verboseLogging">
-        <f:checkbox value="false" />
-      </f:entry>
-      <f:entry title="Additional command line arguments" field="additionalArgs">
-        <f:textbox />
-      </f:entry>
-    </f:advanced>
+        <j:choose>
+      <j:when test="${instance.hasAdvancedOptions()}">
+            <f:entry title="Verbose logging" field="verboseLogging">
+              <f:checkbox value="false" />
+            </f:entry>
+            <f:entry title="Additional command line arguments" field="additionalArgs">
+              <f:textbox />
+            </f:entry>
+          </j:when>
+          <!--NOTE: the double up of the controls in the advanced section, one for when they have a value,
+            to show expanded, the other case when no value set yet -->
+          <j:otherwise>
+            <f:advanced>
+              <f:entry title="Verbose logging" field="verboseLogging">
+                <f:checkbox value="false" />
+              </f:entry>
+              <f:entry title="Additional command line arguments" field="additionalArgs">
+                <f:textbox />
+              </f:entry>
+            </f:advanced>
+          </j:otherwise>
+        </j:choose>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPushRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployPushRecorder/config.jelly
@@ -40,13 +40,27 @@
     </f:entry>
   </f:section>
   <f:section title="Advanced Options">
-    <f:advanced>
-      <f:entry title="Verbose logging" field="verboseLogging">
-        <f:checkbox value="false" />
-      </f:entry>
-      <f:entry title="Additional command line arguments" field="additionalArgs">
-        <f:textbox />
-      </f:entry>
-    </f:advanced>
+    <j:choose>
+      <j:when test="${instance.hasAdvancedOptions()}">
+        <f:entry title="Verbose logging" field="verboseLogging">
+          <f:checkbox value="false" />
+        </f:entry>
+        <f:entry title="Additional command line arguments" field="additionalArgs">
+          <f:textbox />
+        </f:entry>
+      </j:when>
+      <!--NOTE: the double up of the controls in the advanced section, one for when they have a value,
+        to show expanded, the other case when no value set yet -->
+      <j:otherwise>
+        <f:advanced>
+          <f:entry title="Verbose logging" field="verboseLogging">
+            <f:checkbox value="false" />
+          </f:entry>
+          <f:entry title="Additional command line arguments" field="additionalArgs">
+            <f:textbox />
+          </f:entry>
+        </f:advanced>
+      </j:otherwise>
+    </j:choose>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder/config.jelly
@@ -98,13 +98,27 @@
   </f:section>
 
   <f:section title="Advanced Options">
-    <f:advanced>
-      <f:entry title="Verbose logging" field="verboseLogging">
-        <f:checkbox value="false" />
-      </f:entry>
-      <f:entry title="Additional command line arguments" field="additionalArgs">
-        <f:textbox />
-      </f:entry>
-    </f:advanced>
+    <j:choose>
+      <j:when test="${instance.hasAdvancedOptions()}">
+        <f:entry title="Verbose logging" field="verboseLogging">
+          <f:checkbox value="false" />
+        </f:entry>
+        <f:entry title="Additional command line arguments" field="additionalArgs">
+          <f:textbox />
+        </f:entry>
+      </j:when>
+      <!--NOTE: the double up of the controls in the advanced section, one for when they have a value,
+        to show expanded, the other case when no value set yet -->
+      <j:otherwise>
+        <f:advanced>
+          <f:entry title="Verbose logging" field="verboseLogging">
+            <f:checkbox value="false" />
+          </f:entry>
+          <f:entry title="Additional command line arguments" field="additionalArgs">
+            <f:textbox />
+          </f:entry>
+        </f:advanced>
+      </j:otherwise>
+    </j:choose>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
there's no way I could see to have an advanced component, so it's just some conditional decision based on whether any advanced options are set. The penalty is the repated jelly code.

I tried to wrap the `<f:advanced>` and `</f:advanced>` in the `<j:choose>` & `<j:when>` without any luck. It would throw an about lacking the closing `</f:advanced>`.