### PR TITLE
Rename the plugin to 'Octopus Deploy' for better search discoverability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <version>2.7</version>
   </parent>
 
-  <name>OctopusDeploy Plugin</name>
+  <name>Octopus Deploy</name>
   <groupId>hudson.plugins.octopusdeploy</groupId>
   <artifactId>octopusdeploy</artifactId>
   <version>1.10.0-SNAPSHOT</version>


### PR DESCRIPTION
The Jenkins plugin search for "octopus" or "deploy" does not find the Octopus plugin. Only "OctopusDeploy" yields a result. Introducing a space in the plugin name for better searchability and removing the redundant "plugin" word in accordance with style guidelines: https://jenkins.io/doc/developer/publishing/style-guides/

Plugins are keyed on `artifactId`, so the name change should still refer to the same plugin.