### PR TITLE
Fixes #64 Log error message if unable to read the release notes file

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -459,6 +459,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
             try {
                 return StringUtils.join(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8), "\n");
             } catch (IOException ex) {
+                log.error("Failed to read file: " + ex.getMessage());
                 return ERROR_READING;
             }
         }


### PR DESCRIPTION
Reading a .txt fails with no error message, only a <Error Reading Files> is added to the release notes.
It should preferably log the actual IOExecption as it makes it easier to debug why it was not able to read the file.

