### PR TITLE
fixed tool and fs resolution for nodes

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderBuildStep.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderBuildStep.java
@@ -311,8 +311,6 @@ public abstract class AbstractOctopusDeployRecorderBuildStep extends Builder {
 
         checkState(StringUtils.isNotBlank(octopusCli), String.format(OctoConstants.Errors.INPUT_CANNOT_BE_BLANK_MESSAGE_FORMAT, "Octopus CLI"));
 
-        TaskListener taskListener = launcher.getListener();
-
         final String cliPath = getOctopusToolPath(octopusCli, builtOn, environment, launcher.getListener());
         if(StringUtils.isNotBlank(cliPath)) {
             final List<String> cmdArgs = new ArrayList<>();

--- a/src/main/java/hudson/plugins/octopusdeploy/OctoInstallation.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctoInstallation.java
@@ -60,8 +60,20 @@ public class OctoInstallation extends ToolInstallation implements NodeSpecific<O
         return this;
     }
 
-    public String getPathToOctoExe() {
-        return getHome();
+    public String getPathToOctoExe(Node builtOn, EnvVars env, TaskListener taskListener) {
+        OctoInstallation octo = this;
+        if (builtOn != null) {
+            try {
+                octo = this.forNode(builtOn, taskListener);
+            } catch (Exception e) {
+                taskListener.getLogger().println("Failed to resolve octo path on node");
+            }
+        }
+        else if (env != null) {
+            octo = this.forEnvironment(env);
+        }
+
+        return octo.getHome();
     }
 
     public static OctoInstallation getDefaultInstallation() {

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
@@ -152,7 +152,7 @@ public class OctopusDeployDeploymentRecorder extends AbstractOctopusDeployRecord
         if(success) {
             try {
                 final Boolean[] masks = getMasks(commands, OctoConstants.Commands.Arguments.MaskedArguments);
-                Result result = launchOcto(launcher, commands, masks, envVars, listener);
+                Result result = launchOcto(build.getBuiltOn(), launcher, commands, masks, envVars, listener);
                 success = result.equals(Result.SUCCESS);
                 if(success) {
                     String serverUrl = getOctopusDeployServer(serverId).getUrl();

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPackRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPackRecorder.java
@@ -91,7 +91,7 @@ public class OctopusDeployPackRecorder extends AbstractOctopusDeployRecorderBuil
 
         try {
             final Boolean[] masks = getMasks(commands, OctoConstants.Commands.Arguments.MaskedArguments);
-            Result result = launchOcto(launcher, commands, masks, envVars, listener);
+            Result result = launchOcto(build.getBuiltOn(), launcher, commands, masks, envVars, listener);
             success = result.equals(Result.SUCCESS);
         } catch (Exception ex) {
             log.fatal("Failed to package application: " + ex.getMessage());

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorder.java
@@ -84,7 +84,7 @@ public class OctopusDeployPushBuildInformationRecorder extends AbstractOctopusDe
         try {
             final List<String> commands = buildCommands(build, envInjector);
             final Boolean[] masks = getMasks(commands, OctoConstants.Commands.Arguments.MaskedArguments);
-            Result result = launchOcto(launcher, commands, masks, envVars, listener);
+            Result result = launchOcto(build.getBuiltOn(), launcher, commands, masks, envVars, listener);
             success = result.equals(Result.SUCCESS);
         } catch (Exception ex) {
             log.fatal("Failed to push the build information: " + ex.getMessage());

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -155,6 +155,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
     @Override
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
         boolean success = true;
+
         Log log = new Log(listener);
         if (Result.FAILURE.equals(build.getResult())) {
             log.info("Not creating a release due to job being in FAILED state.");
@@ -301,7 +302,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
 
         try {
             final Boolean[] masks = getMasks(commands, OctoConstants.Commands.Arguments.MaskedArguments);
-            Result result = launchOcto(launcher, commands, masks, envVars, listener);
+            Result result = launchOcto(build.getBuiltOn(), launcher, commands, masks, envVars, listener);
             success = result.equals(Result.SUCCESS);
             if (success) {
                 String serverUrl = getOctopusDeployServer(serverId).getUrl();

--- a/src/main/java/hudson/plugins/octopusdeploy/services/FileService.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/FileService.java
@@ -17,5 +17,5 @@ public interface FileService {
      * @return A list of matching files
      */
     @NotNull
-    List<File> getMatchingFile(@NotNull FilePath workingDir, @NotNull String pattern);
+    List<FilePath> getMatchingFile(@NotNull FilePath workingDir, @NotNull String pattern);
 }

--- a/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
@@ -37,10 +37,8 @@ public class FileServiceImpl implements FileService {
         List<FilePath> list = new ArrayList<FilePath>();
         try {
             list = Arrays.asList(workingDir.list(pattern));
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+        } catch (final Exception ex) {
+            throw new ResourceException(ex);
         }
 
         return list;

--- a/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
@@ -2,8 +2,10 @@ package hudson.plugins.octopusdeploy.services.impl;
 
 
 import hudson.FilePath;
+import hudson.model.Computer;
 import hudson.plugins.octopusdeploy.exception.ResourceException;
 import hudson.plugins.octopusdeploy.services.FileService;
+import hudson.slaves.WorkspaceList;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.io.Resource;
@@ -12,8 +14,10 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -26,34 +30,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class FileServiceImpl implements FileService {
     @NotNull
     @Override
-    public List<File> getMatchingFile(@NotNull final FilePath workingDir, @NotNull final String pattern) {
+    public List<FilePath> getMatchingFile(@NotNull final FilePath workingDir, @NotNull final String pattern) {
         checkNotNull(workingDir);
         checkArgument(StringUtils.isNotBlank(pattern));
 
-        final File absoluteFile = new File(pattern);
-        if (absoluteFile.exists()) {
-            return new ArrayList<File>() {{
-                add(absoluteFile);
-            }};
-        }
-
+        List<FilePath> list = new ArrayList<FilePath>();
         try {
-            final List<File> retValue = new ArrayList<File>();
-
-            final String workingDirUri = workingDir.toURI().toString();
-            final ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-            final Resource[] resources = resolver.getResources(workingDirUri + "/" + pattern);
-
-            for (final Resource resource : resources) {
-                final File resourceFile = resource.getFile();
-                if (resourceFile.isFile()) {
-                    retValue.add(resourceFile);
-                }
-            }
-
-            return retValue;
-        } catch (final Exception ex) {
-            throw new ResourceException(ex);
+            list = Arrays.asList(workingDir.list(pattern));
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
+
+        return list;
     }
 }


### PR DESCRIPTION
This PR allows the plugin to consider the per-node tool path override value for resolving the `octo` path.
Also changes file resolution for the `push` step to work for slave nodes.

Source: https://secure.helpscout.net/conversation/1133185955/62148?folderId=557082

Sample log entries:

Push command on a Linux host:
```
[build] $ /home/parallels/.dotnet/tools/dotnet-octo push --server https://ben-test.testoctopus.app --apiKey ******** --package test1.39.zip --package test1.40.zip
```

Create release command, Linux host:
```
[build] $ /home/parallels/.dotnet/tools/dotnet-octo create-release --version 41 --channel Default --releaseNotes "Release created by Build [build #41](http://localhost:8080/jenkins/job/build/41/)" --project 1 --server https://ben-test.testoctopus.app --apiKey ********
Octopus Deploy Command Line Tool, version 7.3.4
Detected automation environment: "Jenkins"
```

Same commands as above, from same project, run on a windows slave node:
```
[build] $ c:\jenkins\tools\octo\octo.exe push --server https://ben-test.testoctopus.app --apiKey ******** --package test1.20.zip
```

```
[build] $ c:\jenkins\tools\octo\octo.exe create-release --version 36 --channel Default --releaseNotes "Release created by Build [build #36](http://localhost:8080/jenkins/job/build/36/)" --project 1 --server https://ben-test.testoctopus.app --apiKey ******** --space Spaces-1
Octopus Deploy Command Line Tool, version 7.3.4
Detected automation environment: "Jenkins"
```