### PR TITLE
Handle executing the push build info step on a slave

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorder.java
@@ -3,11 +3,9 @@ package hudson.plugins.octopusdeploy;
 import com.google.common.base.Splitter;
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Result;
+import hudson.model.*;
 import hudson.plugins.octopusdeploy.constants.OctoConstants;
 import hudson.plugins.octopusdeploy.services.OctopusBuildInformationBuilder;
 import hudson.plugins.octopusdeploy.services.OctopusBuildInformationWriter;
@@ -166,8 +164,7 @@ public class OctopusDeployPushBuildInformationRecorder extends AbstractOctopusDe
      * @return path to build information file
      */
     private String getBuildInformationFromScm(AbstractBuild build, EnvironmentVariableValueInjector envInjector) throws IOException, InterruptedException {
-        String checkoutDir = build.getWorkspace().getRemote();
-        final String buildInformationFile = Paths.get(checkoutDir, "octopus.buildinfo").toAbsolutePath().toString();
+        FilePath ws = build.getWorkspace();
         AbstractProject project = build.getProject();
 
         final OctopusBuildInformationBuilder builder = new OctopusBuildInformationBuilder();
@@ -181,11 +178,12 @@ public class OctopusDeployPushBuildInformationRecorder extends AbstractOctopusDe
                 Integer.toString(build.getNumber())
         );
 
+        final String buildInformationFile = "octopus.buildinfo";
         if (verboseLogging) {
-            log.info("Creating " + buildInformationFile);
+            log.info("Creating " + buildInformationFile + " in " + ws.getRemote());
         }
         final OctopusBuildInformationWriter writer = new OctopusBuildInformationWriter(log, verboseLogging);
-        writer.writeToFile(buildInformation, buildInformationFile);
+        writer.writeToFile(ws, buildInformation, buildInformationFile);
 
         return buildInformationFile;
     }

--- a/src/main/java/hudson/plugins/octopusdeploy/services/OctopusBuildInformationWriter.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/OctopusBuildInformationWriter.java
@@ -2,6 +2,7 @@ package hudson.plugins.octopusdeploy.services;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import hudson.FilePath;
 import hudson.plugins.octopusdeploy.Log;
 import hudson.plugins.octopusdeploy.OctopusBuildInformation;
 
@@ -20,7 +21,7 @@ public class OctopusBuildInformationWriter {
         this.verboseLogging = verboseLogging;
     }
 
-    public void writeToFile(final OctopusBuildInformation octopusBuildInformation, final String buildInformationFile) throws IOException {
+    public void writeToFile(FilePath workspace, final OctopusBuildInformation octopusBuildInformation, final String buildInformationFile) throws IOException, InterruptedException {
         try {
             final Gson gson = new GsonBuilder()
                     .setPrettyPrinting()
@@ -34,15 +35,15 @@ public class OctopusBuildInformationWriter {
             if (verboseLogging) {
                 log.info("Serialized Octopus build information - " + jsonData);
             }
-            OutputStreamWriter bw = new OutputStreamWriter(new FileOutputStream(buildInformationFile), StandardCharsets.UTF_16);
-            bw.write(jsonData);
-            bw.close();
+
+            FilePath newBuildInfoFile = new FilePath(workspace, buildInformationFile);
+            newBuildInfoFile.write(jsonData, StandardCharsets.UTF_16.toString());
 
             if (verboseLogging) {
                 log.info("Wrote " + buildInformationFile);
             }
 
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
             log.error("Error writing " + buildInformationFile + " file");
             throw e;


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/octopus-jenkins-plugin/issues/69

Before:
```
ERROR: Error writing c:\jenkins\workspace\_Misc\AgentAdmin_Test_OctoPlugin\octopus.buildinfo file
FATAL: Failed to push the build information: c:\jenkins\workspace\_Misc\AgentAdmin_Test_OctoPlugin\octopus.buildinfo (The system cannot find the path specified)
```

After from Linux master:
```
Building on master in workspace /home/parallels/git/octopus-jenkins-plugin/work/workspace/octo-push-build-info
INFO: Creating octopus.buildinfo in /home/parallels/git/octopus-jenkins-plugin/work/workspace/octo-push-build-info
```

from Windows slave:
```
Building remotely on windows in workspace c:\Jenkins\workspace\octo-push-build-info
INFO: Creating octopus.buildinfo in c:\Jenkins\workspace\octo-push-build-info
```