### PR TITLE
Fixes #74 - Check file path from pattern before using it as ant glob

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPushRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployPushRecorder.java
@@ -96,7 +96,7 @@ public class OctopusDeployPushRecorder extends AbstractOctopusDeployRecorderBuil
                 .split(packagePathPattern);
         FilePath ws = build.getWorkspace();
         for (final String pattern : patternSplit) {
-            final List<FilePath> matchingFiles = fileService.getMatchingFile(ws, pattern);
+            final List<FilePath> matchingFiles = fileService.getMatchingFile(ws, pattern, log);
             /*
                 Don't add duplicates
              */

--- a/src/main/java/hudson/plugins/octopusdeploy/services/FileService.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/FileService.java
@@ -2,6 +2,7 @@ package hudson.plugins.octopusdeploy.services;
 
 
 import hudson.FilePath;
+import hudson.plugins.octopusdeploy.Log;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -17,5 +18,5 @@ public interface FileService {
      * @return A list of matching files
      */
     @NotNull
-    List<FilePath> getMatchingFile(@NotNull FilePath workingDir, @NotNull String pattern);
+    List<FilePath> getMatchingFile(@NotNull FilePath workingDir, @NotNull String pattern, Log log);
 }

--- a/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
@@ -44,7 +44,7 @@ public class FileServiceImpl implements FileService {
             if(absoluteFile != null)
             {
                 return new ArrayList<FilePath>() {{
-                    add(new FilePath(absoluteFile));
+                    add(new FilePath(workingDir.getChannel(), absoluteFile.getPath()));
                 }};
             }
         } catch (Exception e) { /* don't need to worry if it fails, just fall back to using an ant glob */ }

--- a/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/services/impl/FileServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,13 @@ public class FileServiceImpl implements FileService {
         if (pattern.startsWith("/") || (pattern.startsWith("/") && !pattern.startsWith("//"))) {
             // leading slashes are not valid glob patterns, remove them
             p = pattern.replaceAll("^/+", "").replaceAll("^\\+", "");
+        }
+
+        final File absoluteFile = new File(pattern);
+        if (absoluteFile.exists()) {
+            return new ArrayList<FilePath>() {{
+                add(new FilePath(absoluteFile));
+            }};
         }
 
         List<FilePath> list;


### PR DESCRIPTION
Checks if the pattern is a full file path by seeing if the file exists before trying to use it as an ant glob. 

Fixes: https://github.com/OctopusDeploy/octopus-jenkins-plugin/issues/74