### PR TITLE
Remove references to Octo.exe

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderBuildStep.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderBuildStep.java
@@ -118,7 +118,7 @@ public abstract class AbstractOctopusDeployRecorderBuildStep extends Builder {
     }
 
     /**
-     * The additional arguments to pass to octo.exe
+     * The additional arguments to pass to octo
      */
     protected String additionalArgs;
     public String getAdditionalArgs() {
@@ -337,14 +337,14 @@ public abstract class AbstractOctopusDeployRecorderBuildStep extends Builder {
 
                 exitCode = process.join();
 
-                log.info(String.format("Octo.exe exit code: %d", exitCode));
+                log.info(String.format("Octo CLI exit code: %d", exitCode));
 
             } catch (IOException e) {
-                final String message = "Error from Octo.exe: " + e.getMessage();
+                final String message = "Error from octo CLI: " + e.getMessage();
                 log.error(message);
                 return Result.FAILURE;
             } catch (InterruptedException e) {
-                final String message = "Unable to wait for Octo.exe: " + e.getMessage();
+                final String message = "Unable to wait for octo CLI: " + e.getMessage();
                 log.error(message);
                 return Result.FAILURE;
             }

--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderBuildStep.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderBuildStep.java
@@ -337,7 +337,7 @@ public abstract class AbstractOctopusDeployRecorderBuildStep extends Builder {
 
                 exitCode = process.join();
 
-                log.info(String.format("Octo CLI exit code: %d", exitCode));
+                log.info(String.format("octo CLI exit code: %d", exitCode));
 
             } catch (IOException e) {
                 final String message = "Error from octo CLI: " + e.getMessage();

--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderPostBuildStep.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderPostBuildStep.java
@@ -340,7 +340,7 @@ public abstract class AbstractOctopusDeployRecorderPostBuildStep extends Recorde
 
                 exitCode = process.join();
 
-                log.info(String.format("Octo CLI exit code: %d", exitCode));
+                log.info(String.format("octo CLI exit code: %d", exitCode));
 
             } catch (IOException e) {
                 final String message = "Error from octo CLI: " + e.getMessage();

--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderPostBuildStep.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderPostBuildStep.java
@@ -120,7 +120,7 @@ public abstract class AbstractOctopusDeployRecorderPostBuildStep extends Recorde
     }
 
     /**
-     * The additional arguments to pass to octo.exe
+     * The additional arguments to pass to octo CLI
      */
     protected String additionalArgs;
     public String getAdditionalArgs() {
@@ -340,14 +340,14 @@ public abstract class AbstractOctopusDeployRecorderPostBuildStep extends Recorde
 
                 exitCode = process.join();
 
-                log.info(String.format("Octo.exe exit code: %d", exitCode));
+                log.info(String.format("Octo CLI exit code: %d", exitCode));
 
             } catch (IOException e) {
-                final String message = "Error from Octo.exe: " + e.getMessage();
+                final String message = "Error from octo CLI: " + e.getMessage();
                 log.error(message);
                 return Result.FAILURE;
             } catch (InterruptedException e) {
-                final String message = "Unable to wait for Octo.exe: " + e.getMessage();
+                final String message = "Unable to wait for octo CLI: " + e.getMessage();
                 log.error(message);
                 return Result.FAILURE;
             }


### PR DESCRIPTION
Octo is x-plat now, so removing references to `.exe` and making this lowercase