### PR TITLE
Fixed the validation of the CLI path

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctoInstallation.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctoInstallation.java
@@ -104,7 +104,7 @@ public class OctoInstallation extends ToolInstallation implements NodeSpecific<O
 
     @Override
     public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(OctoInstallation.class);
     }
 
     private static boolean isWindows() {
@@ -141,13 +141,15 @@ public class OctoInstallation extends ToolInstallation implements NodeSpecific<O
          * @param home the path of the file
          * @return Form validation to present on the Jenkins UI
          */
-        public FormValidation doCheckHome(@QueryParameter String home){
-            if(home != null && !home.isEmpty())
+        public FormValidation doCheckHome(@QueryParameter File home){
+            // this can be used to check the existence of a file on the server, so needs to be protected
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+            if(home != null && !home.getPath().isEmpty())
             {
-                File file = new File(home);
-                if (!file.exists()){
+                if (!home.exists()){
                     return FormValidation.warning("No file was found at this path");
-                } else if(!file.canExecute()){
+                } else if(!home.canExecute()){
                     return FormValidation.warning("The file at this path is not executable");
                 }
             }


### PR DESCRIPTION
The validation of the Octopus CLI incorrectly attempts to find a directory instead of a file. This is because the `doCheckHome()` method had the wrong signature, and so the default validation from `hudson.tools.ToolDescriptor.doCheckHome()` was being called.

This PR fixes up the validation so the expected method is called.

# Before

![image](https://user-images.githubusercontent.com/160104/87899927-1be32e80-ca96-11ea-9922-122e3d72ba23.png)


# After

![image](https://user-images.githubusercontent.com/160104/87899921-1685e400-ca96-11ea-9c05-60c5163e99cb.png)


Internal link: https://trello.com/c/acEKN8Ls/3505-jenkins-plugin-has-misleading-warning-message-about-location-of-octo-binary