### PR TITLE
Fix missing additional args field for deploying a deployment step

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderPostBuildStep.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/AbstractOctopusDeployRecorderPostBuildStep.java
@@ -149,6 +149,11 @@ public abstract class AbstractOctopusDeployRecorderPostBuildStep extends Recorde
         return additionalArgs;
     }
 
+    @DataBoundSetter
+    public void setAdditionalArgs(String additionalArgs) {
+        this.additionalArgs = sanitizeValue(additionalArgs);
+    }
+
     /**
      * Whether or not perform will return control immediately, or wait until the Deployment
      * task is completed.

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -160,13 +160,6 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
     }
 
     @DataBoundSetter
-    public void setAdditionalArgs(String addtionalArgs) { this.additionalArgs = sanitizeValue(addtionalArgs); }
-
-    public String getAdditionalArgs() {
-        return this.additionalArgs;
-    }
-
-    @DataBoundSetter
     public void setSpaceId(String spaceId) {
         this.spaceId = sanitizeValue(spaceId);
     }


### PR DESCRIPTION
# Background

`AdditionalArgument` field is missing for `Octopus Deploy Release` step.

# Result

## Before
Unable to set `AdditionalArgument` field to the step.

## After

![image](https://user-images.githubusercontent.com/12688884/109007418-d192f180-76f7-11eb-94c5-ac3d434bf9db.png)
