### PR TITLE
Update jenkins version to 2.303.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 }
 
 jenkinsPlugin {
-  jenkinsVersion = '2.190.1'
+  jenkinsVersion = '2.303.2'
   shortName = 'octopusdeploy'
   displayName = 'Octopus Deploy'
   url = 'https://octopus.com'

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
   </developers>
 
   <properties>
-    <jenkins.version>2.190.1</jenkins.version>
+    <jenkins.version>2.303.2</jenkins.version>
     <slf4jVersion>1.7.26</slf4jVersion>
     <java.level>8</java.level>
     <spotbugs.skip>true</spotbugs.skip>


### PR DESCRIPTION
The version of jenkins which can be launched by the build system (for internal, manual testing) is defined by the jenkins.version property.

Previously it was 2.190, which is nearly 3 years old.

2.303.2 represents the current latest version.