### PR TITLE
BuildInformationRecorder Descriptor test coverage

### DIFF
--- a/src/test/java/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorderDescriptorImplTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/OctopusDeployPushBuildInformationRecorderDescriptorImplTest.java
@@ -1,0 +1,31 @@
+package hudson.plugins.octopusdeploy;
+
+import hudson.util.ListBoxModel;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OctopusDeployPushBuildInformationRecorderDescriptorImplTest {
+
+    private final OctopusDeployPushBuildInformationRecorder.DescriptorImpl descriptor =
+            new OctopusDeployPushBuildInformationRecorder.DescriptorImpl();
+
+    @Test
+    public void isApplicableReturnsTrue() {
+        assertThat(descriptor.isApplicable(null)).isTrue();
+    }
+
+    @Test
+    public void getDisplayNameReturnsFixedName() {
+        assertThat(descriptor.getDisplayName()).isEqualTo("Octopus Deploy: Push build information");
+    }
+
+    @Test
+    public void doFillCommentParserItemsReturnsFixedListBoxModel() {
+        final ListBoxModel model = descriptor.doFillCommentParserItems();
+        assertThat(model)
+                .isNotEmpty()
+                .flatExtracting(ListBoxModel.Option::toString)
+                .containsExactly("=", "Jira=Jira", "GitHub=GitHub");
+    }
+}


### PR DESCRIPTION
- Added unit test coverage for OctopusDeployPushBuildInformationRecorder.DescriptorImpl