### PR TITLE
Update Java Client (SDK)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
       alias('spotless').toPluginId('com.diffplug.spotless').version('5.15.0')
 
       // Libraries
-      version('octopus', '0.0.2-SNAPSHOT')
+      version('octopus', '0.0.3')
       alias('test-support').to('com.octopus', 'test-support').versionRef('octopus')
       alias('octopus-sdk').to('com.octopus', 'octopus-sdk').versionRef('octopus')
       bundle('octopus', ['test-support', 'octopus-sdk'])


### PR DESCRIPTION
 Update to latest SDK version with Log4j version increase to address against Dec2021 0-Day RCE

**N.B:** As the Jenkins plugin has not been released since addition of the Java Client, there is no need for the plugin to be released at present with regards to the Dec2021 Log4J 0-Day RCE.