### PR TITLE
fix: Add back id property as transient so config files from pre-3.1.7 can be read

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployServer.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployServer.java
@@ -20,8 +20,12 @@ public class OctopusDeployServer implements Serializable {
         return isDefault;
     }
 
+    protected transient String id;
+
     private String serverId;
     public String getServerId() {
+        if (id != null) return id;
+
         return serverId;
     }
 


### PR DESCRIPTION
The `id` property will not be written back to XML when data is saved, it will be saved as the new `serverId` field