### PR TITLE
Update our Java SDK to latest version which includes fixes for a log4j vulnerability

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
       alias('spotless').toPluginId('com.diffplug.spotless').version('5.15.0')
 
       // Libraries
-      version('octopus', '0.0.3')
+      version('octopus', '0.0.6')
       alias('test-support').to('com.octopus', 'test-support').versionRef('octopus')
       alias('octopus-sdk').to('com.octopus', 'octopus-sdk').versionRef('octopus')
       bundle('octopus', ['test-support', 'octopus-sdk'])


### PR DESCRIPTION
This is a regression as we shipped a new version of the plugin after moving from Maven to Gradle and our Gradle file referenced an out-of-date version of our Java SDK client.

Fixes #142 