### PR TITLE
chore: name of workflow where no build is required was wrong

### DIFF
--- a/.github/workflows/no-build-required.yml
+++ b/.github/workflows/no-build-required.yml
@@ -1,8 +1,10 @@
-name: 'build-test'
+name: Build and Test
+
 on:
   pull_request:
     path:
       - '**.md'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This mismatch caused the release-please PR to be blocked due to required status check not running