### PR TITLE
Allow for a blank packageReferenceName in packageConfigs

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -489,7 +489,11 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
         } else {
             log.info("Package Configurations:");
             for (PackageConfiguration pc : packageConfigs) {
-                log.info("\t" + pc.getPackageName() + "\t" + pc.getPackageReferenceName() + "\tv" + pc.getPackageVersion());
+                if (StringUtils.isNotBlank(pkg.getPackageReferenceName())) {
+                    log.info("\t" + pc.getPackageName() + "\t" + pc.getPackageReferenceName() + "\tv" + pc.getPackageVersion());
+                } else {
+                    log.info("\t" + pc.getPackageName() + "\tv" + pc.getPackageVersion());
+                }
             }
         }
         log.info("=======================");

--- a/src/main/java/hudson/plugins/octopusdeploy/PackageConfiguration.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/PackageConfiguration.java
@@ -46,6 +46,13 @@ public class PackageConfiguration extends AbstractDescribableImpl<PackageConfigu
         this.packageVersion = packageVersion.trim();
     }
     
+    @DataBoundConstructor
+    public PackageConfiguration(String packageName, String packageVersion) {
+        this.packageName = packageName.trim();
+        this.packageReferenceName = "";
+        this.packageVersion = packageVersion.trim();
+    }
+    
     @Extension
     public static class DescriptorImpl extends Descriptor<PackageConfiguration> {
         @Override


### PR DESCRIPTION
Not 100% sure this is correct, but it seems like the existing code should allow for a PackageConfig with only packageName and packageVersion, but doing that causes null reference errors. It also doesn't generate an octo create-release command that causes the package reference to be User Specified. Instead it chooses Latest Available. 
See issue here: https://github.com/OctopusDeploy/octopus-jenkins-plugin/issues/148

I think something like this would allow us to have a packageConfig with only packageName and packageVersion. It would also work with the existing `StringUtils.isNotBlank(pkg.getPackageReferenceName()` check. 