### PR TITLE
fix: update github workflow and upgrade jenkins plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,18 +137,23 @@ jobs:
           -H "Content-Type: application/json" \
           -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}" \
           -v 2>&1 | grep -i "X-Octopus-Csrf-Token:" | cut -d' ' -f3)
-          
+          echo "CSRF Token: $CSRF_TOKEN"
           echo "Creating API key..."
-          # Create API key with full response output
-          curl -v -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
+          
+          # Single API key creation with verbose output
+          echo "Creating API key..."
+          API_KEY_RESPONSE=$(curl -v -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq '.'
-      
-          API_KEY=$(curl -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
-          -H "Content-Type: application/json" \
           -H "X-Octopus-Csrf-Token: $CSRF_TOKEN" \
-          -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq -r '.ApiKey')
+          -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}")
+          
+          # Debug: Print full API key response
+          echo "Full API Key Response:"
+          echo "$API_KEY_RESPONSE"
+          
+           # Extract API key
+          API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.ApiKey // empty')
           
           echo "::set-output name=api-key::$API_KEY"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,16 +107,16 @@ jobs:
           CONNECTION_STRING="Server=${{ env.MS_SQL_CONTAINER_NETWORK_ALIAS }},${{ env.MS_SQL_PORT }};Database=OctopusDeploy;User=sa;Password=${{ env.SA_PASSWORD }}"
           
           docker run -d \
-            --name octopus-server \
-            --network octopus-network \
-            --network-alias OCTOPUS_SERVER \
-            -p ${{ env.OCTOPUS_SERVER_DEPLOY_PORT }}:8080 \
-            -e ACCEPT_EULA=Y \
-            -e ADMIN_USERNAME=${{ env.OCTOPUS_SERVER_USERNAME }} \
-            -e ADMIN_PASSWORD=${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }} \
-            -e DB_CONNECTION_STRING="$CONNECTION_STRING" \
-            -e OCTOPUS_LICENSE=${{ secrets.OCTOPUS_LICENSE }} \
-            ${{ env.OCTOPUS_SERVER_IMAGE }}
+          --name octopus-server \
+          --network octopus-network \
+          --network-alias OCTOPUS_SERVER \
+          -p ${{ env.OCTOPUS_SERVER_DEPLOY_PORT }}:8080 \
+          -e "ACCEPT_EULA=Y" \
+          -e "ADMIN_USERNAME=${{ env.OCTOPUS_SERVER_USERNAME }}" \
+          -e "ADMIN_PASSWORD=${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}" \
+          -e "DB_CONNECTION_STRING=${CONNECTION_STRING}" \
+          -e "OCTOPUS_LICENSE=${{ secrets.OCTOPUS_LICENSE }}" \
+          "${{ env.OCTOPUS_SERVER_IMAGE }}"
 
       - name: Wait for Octopus Deploy to be ready
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,59 @@ jobs:
           API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
           echo "api-key=$API_KEY" >> $GITHUB_OUTPUT
 
+      - name: Check Octopus License
+        run: |
+          echo "::debug::Checking Octopus license usage..."
+          
+          # Make API request to check license
+          RESPONSE=$(curl -s -H "X-Octopus-ApiKey: ${{ steps.get-api-key.outputs.api-key }}" \
+                        -H "Accept: application/json" \
+                        http://localhost:8080/api/licenses/licenses-current-usage)
+          
+          # Check if curl request was successful
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to make API request"
+            exit 1
+          fi
+          
+          # Parse and display license information
+          IS_PTM=$(echo $RESPONSE | jq -r '.IsPtm')
+          echo "::debug::License Type: $([ "$IS_PTM" == "true" ] && echo "PTM" || echo "Standard")"
+          
+          # Check each limit
+          echo "$RESPONSE" | jq -c '.Limits[]' | while read -r limit; do
+            NAME=$(echo $limit | jq -r '.Name')
+            CURRENT_USAGE=$(echo $limit | jq -r '.CurrentUsage')
+            IS_UNLIMITED=$(echo $limit | jq -r '.IsUnlimited')
+            EFFECTIVE_LIMIT=$(echo $limit | jq -r '.EffectiveLimit')
+          
+            echo "::debug::Checking $NAME - Current Usage: $CURRENT_USAGE"
+          
+            if [ "$IS_UNLIMITED" != "true" ] && [ $CURRENT_USAGE -gt 0 ]; then
+              USAGE_PERCENTAGE=$(awk "BEGIN {printf \"%.2f\", ($CURRENT_USAGE / $EFFECTIVE_LIMIT) * 100}")
+              echo "::debug::$NAME usage: $USAGE_PERCENTAGE%"
+          
+              if [ $(echo "$USAGE_PERCENTAGE > 80" | bc -l) -eq 1 ]; then
+                echo "::warning::High usage detected for $NAME: $USAGE_PERCENTAGE%"
+              fi
+            fi
+          done
+          
+          # Check spaces usage
+          echo "$RESPONSE" | jq -c '.SpacesUsage[]' | while read -r space; do
+            SPACE_NAME=$(echo $space | jq -r '.SpaceName')
+            PROJECTS_COUNT=$(echo $space | jq -r '.ProjectsCount')
+            TENANTS_COUNT=$(echo $space | jq -r '.TenantsCount')
+            MACHINES_COUNT=$(echo $space | jq -r '.MachinesCount')
+          
+            echo "::debug::Space: $SPACE_NAME"
+            echo "::debug::Projects: $PROJECTS_COUNT"
+            echo "::debug::Tenants: $TENANTS_COUNT"
+            echo "::debug::Machines: $MACHINES_COUNT"
+          done
+          
+          echo "::debug::License check completed successfully"
+
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,17 +130,20 @@ jobs:
         run: |
           # Login and save cookies
           curl -c cookies.txt -X POST http://localhost:8080/api/users/login \
-            -H "Content-Type: application/json" \
-            -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}"
-
-          # Get current user ID
-          USER_ID=$(curl -b cookies.txt http://localhost:8080/api/users/me | jq -r '.Id')
-
-          # Create API key
-          API_KEY=$(curl -b cookies.txt -X POST "http://localhost:8080/api/users/${USER_ID}/apikeys" \
-            -H "Content-Type: application/json" \
-            -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq -r '.ApiKey')
-
+          -H "Content-Type: application/json" \
+          -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}"
+          
+          echo "Creating API key..."
+          # Create API key with full response output
+          curl -v -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq '.'
+      
+          API_KEY=$(curl -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
+          -H "Content-Type: application/json" \
+          -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq -r '.ApiKey')
+          
           echo "::set-output name=api-key::$API_KEY"
 
       - name: Build, Execute Unit Tests & E2E Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,28 @@ jobs:
             echo "Version: ${GITVERSION_FULLSEMVER}"
           fi
 
+      # Set up Go for container
+      - name: Set up Go
+        uses: actions/setup-go@v2
+
+      # Start container setup
+      - name: Container Setup
+        run: go test -timeout 0 ./... -createSharedContainer=true
+        env:
+          LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
+          GIT_USERNAME: x-access-token
+          OCTODISABLEOCTOCONTAINERLOGGING: true
+          OCTOTESTSKIPINIT: true
+          GOMAXPROCS: 1
+          OCTOTESTVERSION: latest
+          OCTOTESTIMAGEURL: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
+          OCTOTESTRETRYCOUNT: 1
+
+      # Wait for container to be ready
+      - name: Wait for container
+        run: |
+          timeout 300s bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/api/serverstatus/health)" != "200" ]]; do echo "Waiting for server..."; sleep 5; done' || false
+
       - name: Install Octopus CLI
         uses: OctopusDeploy/install-octopus-cli-action@v1
         with:
@@ -72,14 +94,16 @@ jobs:
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
-          OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
+          OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_CLI_PATH: ${{ steps.cli-path.outputs.install-path }}
+          OCTOPUS_SERVER_URL: http://localhost:8080
 
       - name: Execute Integration Tests
         run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
-          OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
+          OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
+          OCTOPUS_SERVER_URL: http://localhost:8080
 
       - name: Create Plugin Zip
         id: create-package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,6 @@ jobs:
             echo "Version: ${GITVERSION_FULLSEMVER}"
           fi
 
-
       - name: Install Octopus CLI
         uses: OctopusDeploy/install-octopus-cli-action@v1
         with:
@@ -147,9 +146,7 @@ jobs:
           echo "api-key=$API_KEY" >> $GITHUB_OUTPUT
 
       - name: Build, Execute Unit Tests & E2E Tests
-        run: |
-          echo "DEBUG API $OCTOPUS_SERVER_API_KEY"
-          ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
+        run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
@@ -158,7 +155,7 @@ jobs:
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 
       - name: Execute Integration Tests
-        run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
+        run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,30 +145,20 @@ jobs:
           API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
           echo "api-key=$API_KEY" >> $GITHUB_OUTPUT
 
-      - name: Check Octopus License
-        run: |
-          echo "Making API request to check license..."
-          
-          # Make API request and pretty print the JSON response
-          curl -s -H "X-Octopus-ApiKey: $OCTOPUS_SERVER_API_KEY" \
-               -H "Accept: application/json" \
-               "http://localhost:${OCTOPUS_SERVER_DEPLOY_PORT}/api/licenses/licenses-current-usage" | jq '.'
         env:
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
-          OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_CLI_PATH: ${{ steps.cli-path.outputs.install-path }}
           OCTOPUS_SERVER_URL: http://localhost:8080
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 
       - name: Execute Integration Tests
-        run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
+        run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
-          OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_SERVER_URL: http://localhost:8080
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           -e "ADMIN_USERNAME=${{ env.OCTOPUS_SERVER_USERNAME }}" \
           -e "ADMIN_PASSWORD=${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}" \
           -e "DB_CONNECTION_STRING=${CONNECTION_STRING}" \
-          -e "OCTOPUS_LICENSE=${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}" \
+          -e "OCTOPUS_SERVER_BASE64_LICENSE=${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}" \
           "${{ env.OCTOPUS_SERVER_IMAGE }}"
 
       - name: Wait for Octopus Deploy to be ready

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
           done' || false
 
       - name: Build, Execute Unit Tests & E2E Tests
-        run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
+        run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       MS_SQL_CONTAINER_NETWORK_ALIAS: sql-server
       SA_PASSWORD: Password01!
       MS_SQL_PORT: 1433
-      # Octopus Deploy settings
+      # Octopus Server settings
       OCTOPUS_SERVER_IMAGE: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
       OCTOPUS_SERVER_DEPLOY_PORT: 8080
       OCTOPUS_SERVER_USERNAME: admin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
           
            # Extract API key
           API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
-          echo "DEBUG API CREATE $API_KEY"
+          echo "api-key=$API_KEY" >> $GITHUB_OUTPUT
 
       - name: Build, Execute Unit Tests & E2E Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,34 +129,21 @@ jobs:
         id: get-api-key
         run: |
           # Login and save cookies
-          curl -c cookies.txt -X POST http://localhost:8080/api/users/login \
+          curl -c cookies.txt -b cookies.txt -X POST http://localhost:8080/api/users/login \
           -H "Content-Type: application/json" \
           -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}"
           
-          CSRF_TOKEN=$(curl -c cookies.txt -X POST http://localhost:8080/api/users/login \
-          -H "Content-Type: application/json" \
-          -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}" \
-          -v 2>&1 | grep -i "X-Octopus-Csrf-Token:" | cut -d' ' -f3)
-          echo "CSRF Token: $CSRF_TOKEN"
+          CSRF_TOKEN=$(grep 'Octopus-Csrf-Token' cookies.txt | awk '{print $7}')
           echo "Creating API key..."
           
-          # Single API key creation with verbose output
-          echo "Creating API key..."
-          API_KEY_RESPONSE=$(curl -v -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
+          API_KEY_RESPONSE=$(curl -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
           -H "X-Octopus-Csrf-Token: $CSRF_TOKEN" \
-          -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}")
-          
-          # Debug: Print full API key response
-          echo "Full API Key Response:"
-          echo "$API_KEY_RESPONSE"
+          -d '{"Purpose":"GitHub Actions Testing","ExpiresIn":"1.00:00:00"}')
           
            # Extract API key
-          API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.ApiKey // empty')
-          
-          echo "::set-output name=api-key::$API_KEY"
-
+          API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,37 +147,50 @@ jobs:
 
       - name: Check Octopus License
         run: |
-          echo "::debug::Checking Octopus license usage..."
+          echo "Checking Octopus license usage..."
+          
+          # Check required environment variables
+          if [ -z "$OCTOPUS_SERVER_API_KEY" ]; then
+            echo "::error::OCTOPUS_SERVER_API_KEY is not set"
+            exit 1
+          fi
           
           # Make API request to check license
-          RESPONSE=$(curl -s -H "X-Octopus-ApiKey: ${{ steps.get-api-key.outputs.api-key }}" \
+          RESPONSE=$(curl -s -f \
+                        -H "X-Octopus-ApiKey: $OCTOPUS_SERVER_API_KEY" \
                         -H "Accept: application/json" \
-                        http://localhost:8080/api/licenses/licenses-current-usage)
+                        "http://localhost:${OCTOPUS_SERVER_DEPLOY_PORT}/api/licenses/licenses-current-usage")
           
           # Check if curl request was successful
           if [ $? -ne 0 ]; then
-            echo "::error::Failed to make API request"
+            echo "::error::Failed to make API request to Octopus server"
+            exit 1
+          fi
+          
+          # Validate JSON response
+          if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
+            echo "::error::Invalid JSON response from server"
             exit 1
           fi
           
           # Parse and display license information
-          IS_PTM=$(echo $RESPONSE | jq -r '.IsPtm')
-          echo "::debug::License Type: $([ "$IS_PTM" == "true" ] && echo "PTM" || echo "Standard")"
+          IS_PTM=$(echo "$RESPONSE" | jq -r '.IsPtm')
+          echo "License Type: $([ "$IS_PTM" == "true" ] && echo "PTM" || echo "Standard")"
           
           # Check each limit
           echo "$RESPONSE" | jq -c '.Limits[]' | while read -r limit; do
-            NAME=$(echo $limit | jq -r '.Name')
-            CURRENT_USAGE=$(echo $limit | jq -r '.CurrentUsage')
-            IS_UNLIMITED=$(echo $limit | jq -r '.IsUnlimited')
-            EFFECTIVE_LIMIT=$(echo $limit | jq -r '.EffectiveLimit')
+            NAME=$(echo "$limit" | jq -r '.Name')
+            CURRENT_USAGE=$(echo "$limit" | jq -r '.CurrentUsage')
+            IS_UNLIMITED=$(echo "$limit" | jq -r '.IsUnlimited')
+            EFFECTIVE_LIMIT=$(echo "$limit" | jq -r '.EffectiveLimit')
           
-            echo "::debug::Checking $NAME - Current Usage: $CURRENT_USAGE"
+            echo "Checking $NAME - Current Usage: $CURRENT_USAGE"
           
-            if [ "$IS_UNLIMITED" != "true" ] && [ $CURRENT_USAGE -gt 0 ]; then
+            if [ "$IS_UNLIMITED" != "true" ] && [ "$CURRENT_USAGE" -gt 0 ]; then
               USAGE_PERCENTAGE=$(awk "BEGIN {printf \"%.2f\", ($CURRENT_USAGE / $EFFECTIVE_LIMIT) * 100}")
-              echo "::debug::$NAME usage: $USAGE_PERCENTAGE%"
+              echo "$NAME usage: $USAGE_PERCENTAGE%"
           
-              if [ $(echo "$USAGE_PERCENTAGE > 80" | bc -l) -eq 1 ]; then
+              if [ "$(echo "$USAGE_PERCENTAGE > 80" | bc -l)" -eq 1 ]; then
                 echo "::warning::High usage detected for $NAME: $USAGE_PERCENTAGE%"
               fi
             fi
@@ -185,18 +198,20 @@ jobs:
           
           # Check spaces usage
           echo "$RESPONSE" | jq -c '.SpacesUsage[]' | while read -r space; do
-            SPACE_NAME=$(echo $space | jq -r '.SpaceName')
-            PROJECTS_COUNT=$(echo $space | jq -r '.ProjectsCount')
-            TENANTS_COUNT=$(echo $space | jq -r '.TenantsCount')
-            MACHINES_COUNT=$(echo $space | jq -r '.MachinesCount')
+            SPACE_NAME=$(echo "$space" | jq -r '.SpaceName')
+            PROJECTS_COUNT=$(echo "$space" | jq -r '.ProjectsCount')
+            TENANTS_COUNT=$(echo "$space" | jq -r '.TenantsCount')
+            MACHINES_COUNT=$(echo "$space" | jq -r '.MachinesCount')
           
-            echo "::debug::Space: $SPACE_NAME"
-            echo "::debug::Projects: $PROJECTS_COUNT"
-            echo "::debug::Tenants: $TENANTS_COUNT"
-            echo "::debug::Machines: $MACHINES_COUNT"
+            echo "Space: $SPACE_NAME"
+            echo "  Projects: $PROJECTS_COUNT"
+            echo "  Tenants: $TENANTS_COUNT"
+            echo "  Machines: $MACHINES_COUNT"
           done
           
-          echo "::debug::License check completed successfully"
+          echo "License check completed successfully"
+        env:
+          OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           -e "ADMIN_USERNAME=${{ env.OCTOPUS_SERVER_USERNAME }}" \
           -e "ADMIN_PASSWORD=${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}" \
           -e "DB_CONNECTION_STRING=${CONNECTION_STRING}" \
-          -e "OCTOPUS_LICENSE=${{ secrets.OCTOPUS_LICENSE }}" \
+          -e "OCTOPUS_LICENSE=${{ secrets.octopus_secret_2025 }}" \
           "${{ env.OCTOPUS_SERVER_IMAGE }}"
 
       - name: Wait for Octopus Deploy to be ready
@@ -148,7 +148,7 @@ jobs:
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
-          OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
+          OCTOPUS_LICENSE: ${{ secrets.octopus_secret_2025 }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_CLI_PATH: ${{ steps.cli-path.outputs.install-path }}
           OCTOPUS_SERVER_URL: http://localhost:8080
@@ -157,7 +157,7 @@ jobs:
       - name: Execute Integration Tests
         run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
-          OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
+          OCTOPUS_LICENSE: ${{ secrets.octopus_secret_2025 }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_SERVER_URL: http://localhost:8080
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           -e "ADMIN_USERNAME=${{ env.OCTOPUS_SERVER_USERNAME }}" \
           -e "ADMIN_PASSWORD=${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}" \
           -e "DB_CONNECTION_STRING=${CONNECTION_STRING}" \
-          -e "OCTOPUS_LICENSE=${{ secrets.octopus_secret_2025 }}" \
+          -e "OCTOPUS_LICENSE=${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}" \
           "${{ env.OCTOPUS_SERVER_IMAGE }}"
 
       - name: Wait for Octopus Deploy to be ready
@@ -148,7 +148,7 @@ jobs:
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
-          OCTOPUS_LICENSE: ${{ secrets.octopus_secret_2025 }}
+          OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_CLI_PATH: ${{ steps.cli-path.outputs.install-path }}
           OCTOPUS_SERVER_URL: http://localhost:8080
@@ -157,7 +157,7 @@ jobs:
       - name: Execute Integration Tests
         run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
-          OCTOPUS_LICENSE: ${{ secrets.octopus_secret_2025 }}
+          OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_SERVER_URL: http://localhost:8080
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,6 +133,11 @@ jobs:
           -H "Content-Type: application/json" \
           -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}"
           
+          CSRF_TOKEN=$(curl -c cookies.txt -X POST http://localhost:8080/api/users/login \
+          -H "Content-Type: application/json" \
+          -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}" \
+          -v 2>&1 | grep -i "X-Octopus-Csrf-Token:" | cut -d' ' -f3)
+          
           echo "Creating API key..."
           # Create API key with full response output
           curl -v -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
@@ -142,6 +147,7 @@ jobs:
       
           API_KEY=$(curl -b cookies.txt -X POST "http://localhost:8080/api/users/Users-1/apikeys" \
           -H "Content-Type: application/json" \
+          -H "X-Octopus-Csrf-Token: $CSRF_TOKEN" \
           -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq -r '.ApiKey')
           
           echo "::set-output name=api-key::$API_KEY"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,8 +144,12 @@ jobs:
           
            # Extract API key
           API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
+          echo 'DEBUG API CREATE $API_KEY'
+
       - name: Build, Execute Unit Tests & E2E Tests
-        run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
+        run: |
+          echo 'DEBUG API $OCTOPUS_SERVER_API_KEY'
+          ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,16 @@ jobs:
       OCTOPUS_API_KEY: ${{ secrets.OCTOPUS_API_KEY }}
       OCTOPUS_HOST: ${{ secrets.OCTOPUS_URL }}
       OCTOPUS_SPACE: Integrations
+      # SQL Server settings
+      MS_SQL_IMAGE: mcr.microsoft.com/mssql/server
+      MS_SQL_CONTAINER_NETWORK_ALIAS: sql-server
+      SA_PASSWORD: Password01!
+      MS_SQL_PORT: 1433
+      # Octopus Deploy settings
+      OCTOPUS_SERVER_IMAGE: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
+      OCTOPUS_SERVER_DEPLOY_PORT: 8080
+      OCTOPUS_SERVER_USERNAME: admin
+      OCTOPUS_DEPLOY_SERVER_PASSWORD: Password01!
 
     steps:
       - name: Checkout Code
@@ -53,27 +63,6 @@ jobs:
             echo "Version: ${GITVERSION_FULLSEMVER}"
           fi
 
-      # Set up Go for container
-      - name: Set up Go
-        uses: actions/setup-go@v2
-
-      # Start container setup
-      - name: Container Setup
-        run: go test -timeout 0 ./... -createSharedContainer=true
-        env:
-          LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
-          GIT_USERNAME: x-access-token
-          OCTODISABLEOCTOCONTAINERLOGGING: true
-          OCTOTESTSKIPINIT: true
-          GOMAXPROCS: 1
-          OCTOTESTVERSION: latest
-          OCTOTESTIMAGEURL: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
-          OCTOTESTRETRYCOUNT: 1
-
-      # Wait for container to be ready
-      - name: Wait for container
-        run: |
-          timeout 300s bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/api/serverstatus/health)" != "200" ]]; do echo "Waiting for server..."; sleep 5; done' || false
 
       - name: Install Octopus CLI
         uses: OctopusDeploy/install-octopus-cli-action@v1
@@ -89,6 +78,52 @@ jobs:
         with:
           java-version: "8"
           distribution: "adopt"
+
+      - name: Create Docker network
+        run: docker network create octopus-network
+
+      - name: Start SQL Server container
+        run: |
+          docker run -d \
+            --name mssql \
+            --network octopus-network \
+            --network-alias ${{ env.MS_SQL_CONTAINER_NETWORK_ALIAS }} \
+            -p ${{ env.MS_SQL_PORT }}:1433 \
+            -e "SA_PASSWORD=${{ env.SA_PASSWORD }}" \
+            -e "MSSQL_TCP_PORT=${{ env.MS_SQL_PORT }}" \
+            -e "ACCEPT_EULA=Y" \
+            -e "MSSQL_PID=Developer" \
+            ${{ env.MS_SQL_IMAGE }}
+
+      - name: Wait for SQL Server to be ready
+        run: |
+          timeout 300 bash -c 'until docker logs mssql 2>&1 | grep -q "SQL Server is now ready for client connections"; do
+            echo "Waiting for SQL Server to be ready..."
+            sleep 5
+          done' || false
+
+      - name: Start Octopus Deploy container
+        run: |
+          CONNECTION_STRING="Server=${{ env.MS_SQL_CONTAINER_NETWORK_ALIAS }},${{ env.MS_SQL_PORT }};Database=OctopusDeploy;User=sa;Password=${{ env.SA_PASSWORD }}"
+          
+          docker run -d \
+            --name octopus-server \
+            --network octopus-network \
+            --network-alias OCTOPUS_SERVER \
+            -p ${{ env.OCTOPUS_SERVER_DEPLOY_PORT }}:8080 \
+            -e ACCEPT_EULA=Y \
+            -e ADMIN_USERNAME=${{ env.OCTOPUS_SERVER_USERNAME }} \
+            -e ADMIN_PASSWORD=${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }} \
+            -e DB_CONNECTION_STRING="$CONNECTION_STRING" \
+            -e OCTOPUS_LICENSE=${{ secrets.OCTOPUS_LICENSE }} \
+            ${{ env.OCTOPUS_SERVER_IMAGE }}
+
+      - name: Wait for Octopus Deploy to be ready
+        run: |
+          timeout 300 bash -c 'until docker logs octopus-server 2>&1 | grep -q "Web server is ready to process requests"; do
+            echo "Waiting for Octopus Deploy to be ready..."
+            sleep 5
+          done' || false
 
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,11 +144,11 @@ jobs:
           
            # Extract API key
           API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
-          echo 'DEBUG API CREATE $API_KEY'
+          echo "DEBUG API CREATE $API_KEY"
 
       - name: Build, Execute Unit Tests & E2E Tests
         run: |
-          echo 'DEBUG API $OCTOPUS_SERVER_API_KEY'
+          echo "DEBUG API $OCTOPUS_SERVER_API_KEY"
           ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,24 @@ jobs:
             sleep 5
           done' || false
 
+      - name: Get API Key
+        id: get-api-key
+        run: |
+          # Login and save cookies
+          curl -c cookies.txt -X POST http://localhost:8080/api/users/login \
+            -H "Content-Type: application/json" \
+            -d "{\"Username\":\"${{ env.OCTOPUS_SERVER_USERNAME }}\",\"Password\":\"${{ env.OCTOPUS_DEPLOY_SERVER_PASSWORD }}\"}"
+
+          # Get current user ID
+          USER_ID=$(curl -b cookies.txt http://localhost:8080/api/users/me | jq -r '.Id')
+
+          # Create API key
+          API_KEY=$(curl -b cookies.txt -X POST "http://localhost:8080/api/users/${USER_ID}/apikeys" \
+            -H "Content-Type: application/json" \
+            -d "{\"Purpose\":\"GitHub Actions Testing\",\"ExpiresIn\":\"1.00:00:00\"}" | jq -r '.ApiKey')
+
+          echo "::set-output name=api-key::$API_KEY"
+
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }} --info --stacktrace
         env:
@@ -132,6 +150,7 @@ jobs:
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_CLI_PATH: ${{ steps.cli-path.outputs.install-path }}
           OCTOPUS_SERVER_URL: http://localhost:8080
+          OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 
       - name: Execute Integration Tests
         run: ./gradlew integrationTest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
@@ -139,6 +158,7 @@ jobs:
           OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
           OCTOPUS_SDK_AT_USE_EXISTING_SERVER: true
           OCTOPUS_SERVER_URL: http://localhost:8080
+          OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 
       - name: Create Plugin Zip
         id: create-package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,10 +56,10 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "schedule" ]
           then
-            echo "::set-output name=nuGetVersion::${GITVERSION_MAJORMINORPATCH}-nightly-${{ github.run_number }}"
+            echo "nuGetVersion=${GITVERSION_MAJORMINORPATCH}-nightly-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "Version: ${GITVERSION_MAJORMINORPATCH}-nightly-${{ github.run_number }}"
           else
-            echo "::set-output name=nuGetVersion::${GITVERSION_FULLSEMVER}"
+            echo "nuGetVersion=${GITVERSION_FULLSEMVER}" >> $GITHUB_OUTPUT
             echo "Version: ${GITVERSION_FULLSEMVER}"
           fi
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Set Octo CLI Path
         id: cli-path
-        run: echo "::set-output name=install-path::$(which octo)"
+        run: echo "install-path=$(which octo)" >> $GITHUB_OUTPUT
 
       - name: Setup JDK8
         uses: actions/setup-java@v3
@@ -145,9 +145,6 @@ jobs:
           API_KEY=$(echo "$API_KEY_RESPONSE" | grep -o '"ApiKey": *"[^"]*"' | sed 's/"ApiKey": *"\([^"]*\)"/\1/')
           echo "api-key=$API_KEY" >> $GITHUB_OUTPUT
 
-        env:
-          OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
-
       - name: Build, Execute Unit Tests & E2E Tests
         run: ./gradlew build test -Pversion=${{ steps.git-version.outputs.nugetVersion }}
         env:
@@ -171,7 +168,7 @@ jobs:
           find . -wholename '**/octopusdeploy/${{ steps.git-version.outputs.nugetVersion }}/*' -print | zip -j ${{ github.workspace }}/Octopus.Jenkins.${{ steps.git-version.outputs.nugetVersion }}.zip -@  
           popd
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Octopus.Jenkins.${{ steps.git-version.outputs.nugetVersion }}
           path: "Octopus.Jenkins.${{ steps.git-version.outputs.nugetVersion }}.zip"
@@ -188,7 +185,7 @@ jobs:
           echo "::debug::${{github.event_name}}"
           OUTPUT_FILE="release_notes.txt"
           jq --raw-output '.release.body' ${{ github.event_path }} | sed 's#\r#  #g' > $OUTPUT_FILE
-          echo "::set-output name=release-note-file::$OUTPUT_FILE"
+          echo "release-note-file=$OUTPUT_FILE" >> $GITHUB_OUTPUT
 
       - name: Create a release in Octopus Deploy 🐙
         uses: OctopusDeploy/create-release-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,69 +147,12 @@ jobs:
 
       - name: Check Octopus License
         run: |
-          echo "Checking Octopus license usage..."
+          echo "Making API request to check license..."
           
-          # Check required environment variables
-          if [ -z "$OCTOPUS_SERVER_API_KEY" ]; then
-            echo "::error::OCTOPUS_SERVER_API_KEY is not set"
-            exit 1
-          fi
-          
-          # Make API request to check license
-          RESPONSE=$(curl -s -f \
-                        -H "X-Octopus-ApiKey: $OCTOPUS_SERVER_API_KEY" \
-                        -H "Accept: application/json" \
-                        "http://localhost:${OCTOPUS_SERVER_DEPLOY_PORT}/api/licenses/licenses-current-usage")
-          
-          # Check if curl request was successful
-          if [ $? -ne 0 ]; then
-            echo "::error::Failed to make API request to Octopus server"
-            exit 1
-          fi
-          
-          # Validate JSON response
-          if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
-            echo "::error::Invalid JSON response from server"
-            exit 1
-          fi
-          
-          # Parse and display license information
-          IS_PTM=$(echo "$RESPONSE" | jq -r '.IsPtm')
-          echo "License Type: $([ "$IS_PTM" == "true" ] && echo "PTM" || echo "Standard")"
-          
-          # Check each limit
-          echo "$RESPONSE" | jq -c '.Limits[]' | while read -r limit; do
-            NAME=$(echo "$limit" | jq -r '.Name')
-            CURRENT_USAGE=$(echo "$limit" | jq -r '.CurrentUsage')
-            IS_UNLIMITED=$(echo "$limit" | jq -r '.IsUnlimited')
-            EFFECTIVE_LIMIT=$(echo "$limit" | jq -r '.EffectiveLimit')
-          
-            echo "Checking $NAME - Current Usage: $CURRENT_USAGE"
-          
-            if [ "$IS_UNLIMITED" != "true" ] && [ "$CURRENT_USAGE" -gt 0 ]; then
-              USAGE_PERCENTAGE=$(awk "BEGIN {printf \"%.2f\", ($CURRENT_USAGE / $EFFECTIVE_LIMIT) * 100}")
-              echo "$NAME usage: $USAGE_PERCENTAGE%"
-          
-              if [ "$(echo "$USAGE_PERCENTAGE > 80" | bc -l)" -eq 1 ]; then
-                echo "::warning::High usage detected for $NAME: $USAGE_PERCENTAGE%"
-              fi
-            fi
-          done
-          
-          # Check spaces usage
-          echo "$RESPONSE" | jq -c '.SpacesUsage[]' | while read -r space; do
-            SPACE_NAME=$(echo "$space" | jq -r '.SpaceName')
-            PROJECTS_COUNT=$(echo "$space" | jq -r '.ProjectsCount')
-            TENANTS_COUNT=$(echo "$space" | jq -r '.TenantsCount')
-            MACHINES_COUNT=$(echo "$space" | jq -r '.MachinesCount')
-          
-            echo "Space: $SPACE_NAME"
-            echo "  Projects: $PROJECTS_COUNT"
-            echo "  Tenants: $TENANTS_COUNT"
-            echo "  Machines: $MACHINES_COUNT"
-          done
-          
-          echo "License check completed successfully"
+          # Make API request and pretty print the JSON response
+          curl -s -H "X-Octopus-ApiKey: $OCTOPUS_SERVER_API_KEY" \
+               -H "Accept: application/json" \
+               "http://localhost:${OCTOPUS_SERVER_DEPLOY_PORT}/api/licenses/licenses-current-usage" | jq '.'
         env:
           OCTOPUS_SERVER_API_KEY: ${{ steps.get-api-key.outputs.api-key }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 }
 
 jenkinsPlugin {
-  jenkinsVersion = '2.401.1'
+  jenkinsVersion = '2.462.3'
   shortName = 'octopusdeploy'
   displayName = 'Octopus Deploy'
   url = 'https://github.com/OctopusDeploy/octopus-jenkins-plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ dependencyResolutionManagement {
   versionCatalogs {
     libs {
       // Plugins
-      alias('jenkins').toPluginId('org.jenkins-ci.jpi').version('0.43.0')
+      alias('jenkins').toPluginId('org.jenkins-ci.jpi').version('0.46.0')
       alias('license').toPluginId('com.github.hierynomus.license').version('0.16.1')
       alias('spotless').toPluginId('com.diffplug.spotless').version('5.15.0')
 

--- a/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
+++ b/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
@@ -86,6 +86,13 @@ public class BaseIntegrationTest extends BaseOctopusServerEnabledTest {
         SpaceOverviewResource spaceOverviewResource = new SpaceOverviewWithLinks(generateSpaceName(testInfo.getDisplayName()), spaceManagers);
         final Set<String> spaceManagersTeams = Sets.newHashSet("teams-everyone");
         spaceOverviewResource.setSpaceManagersTeams(spaceManagersTeams);
+        repository.spaces().getAll().forEach(space -> {
+            try {
+                repository.spaces().delete(space.getProperties());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
         space = repository
                 .spaces()
                 .create(spaceOverviewResource);

--- a/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
+++ b/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
@@ -86,13 +86,6 @@ public class BaseIntegrationTest extends BaseOctopusServerEnabledTest {
         SpaceOverviewResource spaceOverviewResource = new SpaceOverviewWithLinks(generateSpaceName(testInfo.getDisplayName()), spaceManagers);
         final Set<String> spaceManagersTeams = Sets.newHashSet("teams-everyone");
         spaceOverviewResource.setSpaceManagersTeams(spaceManagersTeams);
-        repository.spaces().getAll().forEach(space -> {
-            try {
-                repository.spaces().delete(space.getProperties());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
         space = repository
                 .spaces()
                 .create(spaceOverviewResource);

--- a/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
+++ b/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.octopus.helper;
 
 import com.google.common.collect.Sets;
+import com.octopus.openapi.model.TeamResource;
 import com.octopus.sdk.Repository;
 import com.octopus.sdk.api.SpaceOverviewApi;
 import com.octopus.sdk.api.UserApi;
@@ -16,6 +17,7 @@ import com.octopus.sdk.model.lifecycle.LifecycleResource;
 import com.octopus.sdk.model.project.ProjectResource;
 import com.octopus.sdk.model.projectgroup.ProjectGroupResource;
 import com.octopus.sdk.model.release.ReleaseResource;
+import com.octopus.sdk.model.space.SpaceOverviewResource;
 import com.octopus.sdk.model.space.SpaceOverviewWithLinks;
 import com.octopus.sdk.model.tag.TagResource;
 import com.octopus.sdk.model.tagset.TagSetResource;
@@ -82,9 +84,12 @@ public class BaseIntegrationTest extends BaseOctopusServerEnabledTest {
         final Set<String> spaceManagers =
                 Sets.newHashSet(UserApi.create(client).getCurrentUser().getProperties().getId());
         final Repository repository = new Repository(client);
+        SpaceOverviewResource spaceOverviewResource = new SpaceOverviewWithLinks(generateSpaceName(testInfo.getDisplayName()), spaceManagers);
+        final Set<String> spaceManagersTeams = Sets.newHashSet("teams-everyone");
+        spaceOverviewResource.setSpaceManagersTeams(spaceManagersTeams);
         space = repository
                 .spaces()
-                .create(new SpaceOverviewWithLinks(generateSpaceName(testInfo.getDisplayName()), spaceManagers));
+                .create(spaceOverviewResource);
         initTestEnvironment();
     }
 

--- a/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
+++ b/src/integration-test/java/com/octopus/helper/BaseIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.octopus.helper;
 
 import com.google.common.collect.Sets;
-import com.octopus.openapi.model.TeamResource;
 import com.octopus.sdk.Repository;
 import com.octopus.sdk.api.SpaceOverviewApi;
 import com.octopus.sdk.api.UserApi;

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -7,6 +7,7 @@ import com.octopus.sdk.http.OctopusClient;
 import com.octopus.testsupport.OctopusDeployServerFactory;
 import hudson.model.FreeStyleProject;
 import okhttp3.OkHttpClient;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,7 @@ public class E2eTest {
 
     private final com.octopus.testsupport.OctopusDeployServer server = OctopusDeployServerFactory.create();
     private Space space;
+    private OctopusClient client;
 
     @Rule
     public final JenkinsRule jenkinsRule = new JenkinsRule();
@@ -60,7 +62,7 @@ public class E2eTest {
         cliDescriptor.save();
 
         // Get Space and configure Octopus server for tests
-        final OctopusClient client =
+        client =
                 new OctopusClient(new OkHttpClient(), new URL(server.getOctopusUrl()), server.getApiKey());
         space = new Repository(client).spaces().getAll().get(0);
     }
@@ -94,6 +96,13 @@ public class E2eTest {
 
         return rawConfig.replace("<outputPath>.</outputPath>",
                 "<outputPath>" + temporaryFolder.getRoot() + "</outputPath>");
+    }
+
+    @After
+    public void cleanUp() throws IOException {
+        if (space != null) {
+            new Repository(client).spaces().delete(space.getProperties().getId());
+        }
     }
 
 }

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -83,7 +83,7 @@ public class E2eTest {
 
         // OctopusDeployPushBuildInformationRecorder - Build info pushed to Octopus
         assertThat(space.buildInformation().getAll().stream().map(BuildInformation::getProperties))
-                .flatExtracting("packageId", "version").contains("PackageId", "2.0.0");
+                .flatExtracting("packageId", "version").contains("PackageId", "1.0.0");
     }
 
     private String getProjectConfiguration() throws URISyntaxException, IOException {

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -99,13 +99,13 @@ public class E2eTest {
                 "<outputPath>" + temporaryFolder.getRoot() + "</outputPath>");
     }
 
-    @After
-    public void cleanUp() throws IOException {
-        SpaceOverviewApi spaceOverviewApi = SpaceOverviewApi.create(client);
-        if (space != null) {
-            space.getProperties().setTaskQueueStopped(true);
-            spaceOverviewApi.update(space.getProperties());
-            spaceOverviewApi.delete(space.getProperties());
-        }
-    }
+//    @After
+//    public void cleanUp() throws IOException {
+//        SpaceOverviewApi spaceOverviewApi = SpaceOverviewApi.create(client);
+//        if (space != null) {
+//            space.getProperties().setTaskQueueStopped(true);
+//            spaceOverviewApi.update(space.getProperties());
+//            spaceOverviewApi.delete(space.getProperties());
+//        }
+//    }
 }

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.octopusdeploy;
 
 import com.octopus.sdk.Repository;
+import com.octopus.sdk.api.SpaceOverviewApi;
 import com.octopus.sdk.domain.BuildInformation;
 import com.octopus.sdk.domain.Space;
 import com.octopus.sdk.http.OctopusClient;
@@ -100,9 +101,11 @@ public class E2eTest {
 
     @After
     public void cleanUp() throws IOException {
+        SpaceOverviewApi spaceOverviewApi = SpaceOverviewApi.create(client);
         if (space != null) {
-            new Repository(client).spaces().delete(space.getProperties().getId());
+            space.getProperties().setTaskQueueStopped(true);
+            spaceOverviewApi.update(space.getProperties());
+            spaceOverviewApi.delete(space.getProperties());
         }
     }
-
 }

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -1,14 +1,12 @@
 package hudson.plugins.octopusdeploy;
 
 import com.octopus.sdk.Repository;
-import com.octopus.sdk.api.SpaceOverviewApi;
 import com.octopus.sdk.domain.BuildInformation;
 import com.octopus.sdk.domain.Space;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.testsupport.OctopusDeployServerFactory;
 import hudson.model.FreeStyleProject;
 import okhttp3.OkHttpClient;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +34,6 @@ public class E2eTest {
 
     private final com.octopus.testsupport.OctopusDeployServer server = OctopusDeployServerFactory.create();
     private Space space;
-    private OctopusClient client;
 
     @Rule
     public final JenkinsRule jenkinsRule = new JenkinsRule();
@@ -63,7 +60,7 @@ public class E2eTest {
         cliDescriptor.save();
 
         // Get Space and configure Octopus server for tests
-        client =
+        final OctopusClient client =
                 new OctopusClient(new OkHttpClient(), new URL(server.getOctopusUrl()), server.getApiKey());
         space = new Repository(client).spaces().getAll().get(0);
     }
@@ -98,14 +95,4 @@ public class E2eTest {
         return rawConfig.replace("<outputPath>.</outputPath>",
                 "<outputPath>" + temporaryFolder.getRoot() + "</outputPath>");
     }
-
-//    @After
-//    public void cleanUp() throws IOException {
-//        SpaceOverviewApi spaceOverviewApi = SpaceOverviewApi.create(client);
-//        if (space != null) {
-//            space.getProperties().setTaskQueueStopped(true);
-//            spaceOverviewApi.update(space.getProperties());
-//            spaceOverviewApi.delete(space.getProperties());
-//        }
-//    }
 }

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -95,4 +95,5 @@ public class E2eTest {
         return rawConfig.replace("<outputPath>.</outputPath>",
                 "<outputPath>" + temporaryFolder.getRoot() + "</outputPath>");
     }
+
 }

--- a/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
+++ b/src/test/java/hudson/plugins/octopusdeploy/E2eTest.java
@@ -83,7 +83,7 @@ public class E2eTest {
 
         // OctopusDeployPushBuildInformationRecorder - Build info pushed to Octopus
         assertThat(space.buildInformation().getAll().stream().map(BuildInformation::getProperties))
-                .flatExtracting("packageId", "version").contains("PackageId", "1.0.0");
+                .flatExtracting("packageId", "version").contains("PackageId", "2.0.0");
     }
 
     private String getProjectConfiguration() throws URISyntaxException, IOException {


### PR DESCRIPTION
- Updates `org.jenkins-ci.jpi` from 0.43.0 to 0.46.0
   - 0.43.0 was referencing `org.jvnet.localizer:maven-localizer-plugin:1.24 `which would not be found
- Updates `Jenkins Plugin` from 2.401.1 to 2.462.3
  - 2.462.3 is the last version that supports java 11 and includes the snakeyaml security updates
- Updates `Build and Test` Github Action to run docker containers for the db and server for testing
- Updates `Build and Test` Github Action to remove deprecated use of `set-output` and `actions/upload-artifact@v3`
- Updates `BaseIntegrationTest.java` to include the required SpaceManagersTeams

Fixes https://github.com/OctopusDeploy/octopus-jenkins-plugin/issues/156

[sc-100561]

`INTEGRATIONS_FNM_BOT_TOKEN` may need to be updated for release please to run.