### PR TITLE
fix: remove octopus bundle from runtime dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ configurations {
 }
 
 dependencies {
-  implementation libs.bundles.octopus
   implementation libs.apache.commons.collections4
   implementation libs.google.gson
   implementation libs.jenkins.workflow


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/octopus-jenkins-plugin/issues/156

Upon further investigation it was found that snakeyaml 1.26 is brought in by the octopus-sdk dependency.

As the octopus-sdk is only used for testing, we have removed this dependency from the runtime dependencies.

Customer ran:
`ls /pipeline/builds/jenkins/plugins/octopusdeploy/WEB-INF/lib | grep snake`
Returned:
`snakeyaml-1.26.jar`

Local Testing:
1. Built package locally 
`./gradlew clean assemble `
3. Unpacked package 
`mkdir unpacked`
`unzip build/libs/octopusdeploy.hpi -d unpacked`
4. Checked for snakeyaml
`ls unpacked/WEB-INF/lib | grep snake`
5. Nothing was returned

[sc-100561]

