### PR TITLE
fix: Simplifies how release notes are read from a file by removing error-swallowing behavior

### DIFF
--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -295,7 +295,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
                 try {
                     releaseNotesContent += getReleaseNotesFromFile(workspace, releaseNotesFile);
                 } catch (Exception ex) {
-                    log.fatal(String.format("Unable to get file contents from release notes file! - %s", getExceptionMessage(ex)));
+                    log.fatal(String.format("Unable to get file contents from release notes file '%s'! - %s", releaseNotesFile, getExceptionMessage(ex)));
                     success = false;
                 }
             } else if (isReleaseNotesSourceScm()) {
@@ -475,6 +475,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
     /**
      * Return the release notes contents from a file.
      * @param workspace our build
+     * @param releaseNotesFilename the name of the file that contains the release notes
      * @return string contents of file
      * @throws IOException if there was a file read io problem
      * @throws InterruptedException if the action for reading was interrupted

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -293,7 +293,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
         if (releaseNotes) {
             if (isReleaseNotesSourceFile()) {
                 try {
-                    releaseNotesContent += getReleaseNotesFromFile(workspace, releaseNotesFile, log);
+                    releaseNotesContent += getReleaseNotesFromFile(workspace, releaseNotesFile);
                 } catch (Exception ex) {
                     log.fatal(String.format("Unable to get file contents from release notes file! - %s", getExceptionMessage(ex)));
                     success = false;
@@ -479,32 +479,18 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorderP
      * @throws IOException if there was a file read io problem
      * @throws InterruptedException if the action for reading was interrupted
      */
-    private String getReleaseNotesFromFile(FilePath workspace, String releaseNotesFilename, Log log) throws IOException, InterruptedException {
+    private String getReleaseNotesFromFile(FilePath workspace, String releaseNotesFilename) throws IOException, InterruptedException {
         FilePath path = new FilePath(workspace, releaseNotesFilename);
-        return path.act(new ReadFileCallable(log));
+        return path.act(new ReadFileCallable());
     }
 
     /**
      * This callable allows us to read files from other nodes - ie. Jenkins slaves.
      */
     private static final class ReadFileCallable implements FileCallable<String> {
-        public final static String ERROR_READING = "<Error Reading File>";
-
-        private final Log log;
-
-        public ReadFileCallable(Log log)
-        {
-            this.log = log;
-        }
-
         @Override
-        public String invoke(File f, VirtualChannel channel) {
-            try {
-                return StringUtils.join(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8), "\n");
-            } catch (IOException ex) {
-                log.error("Failed to read file: " + getExceptionMessage(ex));
-                return ERROR_READING;
-            }
+        public String invoke(File f, VirtualChannel channel) throws IOException {
+            return StringUtils.join(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8), "\n");
         }
 
         @Override


### PR DESCRIPTION
## Before

```
INFO: Started Octopus Release
INFO: =======================
INFO: Project: Jenkins
INFO: Release Version: 0.0.13
INFO: Channel: Default
INFO: Include Release Notes?: true
INFO: 	Release Notes Source: file
INFO: 	Release Notes File: rn.txt
INFO: Deploy this Release?: false
INFO: Package Configurations: none
INFO: =======================
FATAL: Unable to get file contents from release notes file! - Unable to serialize hudson.plugins.octopusdeploy.OctopusDeployReleaseRecorder$ReadFileCallable@44d9e8eb
java.io.IOException: Unable to serialize hudson.plugins.octopusdeploy.OctopusDeployReleaseRecorder$ReadFileCallable@44d9e8eb
```

## After

```
INFO: Started Octopus Release
INFO: =======================
INFO: Project: Jenkins
INFO: Release Version: 0.0.12
INFO: Channel: Default
INFO: Include Release Notes?: true
INFO: 	Release Notes Source: file
INFO: 	Release Notes File: rn.txt
INFO: Deploy this Release?: false
INFO: Package Configurations: none
INFO: =======================
$ C:\octopus\Octo.exe config list
[test-octopus-plugin] $ C:\octopus\Octo.exe login --server <server> --api-key ******** --no-prompt --output-format json
Testing login to Octopus Server: <server>
Configuring CLI to use API key for Octopus Server: <server>
Login successful, happy deployments!
INFO: Octopus CLI exit code: 0
[test-octopus-plugin] $ C:\octopus\Octo.exe release create --project Jenkins --space Default --no-prompt --output-format json --version 0.0.12 --channel Default --release-notes TESTING
{"ID":"Releases-923","ReleaseNotes":"TESTING","Assembled":"2026-04-16T00:16:38.429Z","Channel":"Default","Version":"0.0.12"}
INFO: Octopus CLI exit code: 0
```

Fixes #167
Fixes HPY-1348

BEGIN_COMMIT_OVERRIDE
fix: Simplify how release notes are read from a file by removing error-swallowing behavior
END_COMMIT_OVERRIDE